### PR TITLE
Fix NVME issue with message reply

### DIFF
--- a/ceph-nvme/charmcraft.yaml
+++ b/ceph-nvme/charmcraft.yaml
@@ -16,7 +16,7 @@ parts:
       ./spdk/configure --with-rbd --disable-tests --disable-unit-tests \
                        --disable-debug --disable-examples --without-golang \
                        --without-shared --without-iscsi-initiator \
-                       --disable-cet --without-daos
+                       --disable-cet --without-daos --target-arch=x86-64-v2
       make -C spdk -j `(nproc --ignore=4)`
       find ./spdk/build/bin ! -name 'nvmf_tgt' -type f -exec rm -f {} +
       find ./spdk -name '*.o' -type f -delete

--- a/ceph-nvme/src/charm.py
+++ b/ceph-nvme/src/charm.py
@@ -190,7 +190,7 @@ class CephNVMECharm(ops.CharmBase):
 
         err = str(res['error'])
         logging.error('failed to create cluster: %s' % err)
-        event.fail('failed to create cluster: %s' % err)
+        event.defer()
 
     @staticmethod
     def _get_unit_addr(unit, rel_id):

--- a/ceph-nvme/src/charm.py
+++ b/ceph-nvme/src/charm.py
@@ -177,7 +177,7 @@ class CephNVMECharm(ops.CharmBase):
             user=self.app_name, key=data['key'],
             mon_host=','.join(data['mon_hosts']),
             name='ceph.%s' % next(iter(relation)).id)
-        res = self._msgloop(msg)
+        res = self._msgloop(msg, addr='127.0.0.1')
         if 'error' not in res:
             return
 
@@ -454,7 +454,7 @@ class CephNVMECharm(ops.CharmBase):
         if num_max <= 0:
             num_max = len(peers)
 
-        tmp = self._msgloop(self.rpc.find(nqn=nqn))
+        tmp = self._msgloop(self.rpc.find(nqn=nqn), addr='127.0.0.1')
         if tmp and 'error' not in tmp:
             event.fail('unit already handles NQN')
             return
@@ -472,7 +472,7 @@ class CephNVMECharm(ops.CharmBase):
         self._event_set_create_results(event, bdev, joined)
 
     def on_list_endpoints_action(self, event):
-        elems = self._msgloop({'method': 'list'})
+        elems = self._msgloop({'method': 'list'}, addr='127.0.0.1')
         event.set_results({'endpoints': elems})
 
     def on_add_host_action(self, event):
@@ -512,7 +512,7 @@ class CephNVMECharm(ops.CharmBase):
 
     def on_list_hosts_action(self, event):
         nqn = event.params.get('nqn')
-        res = self._msgloop(self.rpc.host_list(nqn=nqn))
+        res = self._msgloop(self.rpc.host_list(nqn=nqn), addr='127.0.0.1')
 
         if 'error' in res:
             event.fail('NQN %s not found' % nqn)

--- a/ceph-nvme/src/charm.py
+++ b/ceph-nvme/src/charm.py
@@ -190,9 +190,7 @@ class CephNVMECharm(ops.CharmBase):
 
         err = str(res['error'])
         logging.error('failed to create cluster: %s' % err)
-        self.unit.status = ops.BlockedStatus(
-            'failed to create cluster: %s' % err)
-        event.defer()
+        event.fail('failed to create cluster: %s' % err)
 
     @staticmethod
     def _get_unit_addr(unit, rel_id):

--- a/ceph-nvme/unit_tests/test_charm.py
+++ b/ceph-nvme/unit_tests/test_charm.py
@@ -122,6 +122,7 @@ class TestCharm(unittest.TestCase):
             check_output, cached_resp=cached_resp)
 
         charm._stored.installed_services = True
+
         def _fail(_):
             raise RuntimeError("cannot call 'fail' on Pool Events")
 

--- a/ceph-nvme/unit_tests/test_charm.py
+++ b/ceph-nvme/unit_tests/test_charm.py
@@ -25,13 +25,14 @@ import src.charm as charm
 
 
 class MockSocket:
-    def __init__(self, skip_first=False):
+    def __init__(self, skip_first=False, cached_resp={}):
         self.sendto = mock.MagicMock()
         self.sendto.side_effect = self._sendto
         self.recv = mock.MagicMock()
         self.recv.side_effect = self._recv
         self.response = None
         self.skip_first = skip_first
+        self.cached_resp = cached_resp
 
     def _sendto(self, msg, *args):
         self.response = self._compute_response(msg)
@@ -47,7 +48,10 @@ class MockSocket:
     def _compute_response(self, msg):
         msg = json.loads(msg)
         method = msg['method']
-        if method not in ('create', 'list', 'find', 'host_add', 'host_del'):
+        resp = self.cached_resp.get(method)
+        if resp is not None:
+            return resp
+        elif method not in ('create', 'list', 'find', 'host_add', 'host_del'):
             return b'{}'
 
         ret = {'nqn': 'nqn.1', 'addr': '3.3.3.3', 'port': 1,
@@ -81,7 +85,8 @@ class TestCharm(unittest.TestCase):
             'ceph-mon/0',
             {
                 'key': 'some-key',
-                'mon_hosts': '2.2.2.2'
+                'mon_hosts': '2.2.2.2',
+                'auth': 'some-auth',
             })
 
     def _check_calls(self, call_args_list, expected):
@@ -109,6 +114,20 @@ class TestCharm(unittest.TestCase):
         self.add_peers()
         self.add_ceph_relation()
         return charm, rpc_sock, event
+
+    @mock.patch.object(charm.subprocess, 'check_output')
+    def test_broken_ceph_relation(self, check_output):
+        cached_resp = {'cluster_add': b'{"error": {"code": -2}}'}
+        charm, rpc_sock, event = self._setup_mock_params(
+            check_output, cached_resp=cached_resp)
+
+        charm._stored.installed_services = True
+        def _fail(_):
+            raise RuntimeError("cannot call 'fail' on Pool Events")
+
+        event.fail = _fail
+        charm._on_ceph_relation_changed(event)
+        event.defer.assert_called()
 
     @mock.patch.object(charm.subprocess, 'check_output')
     def test_create(self, check_output):


### PR DESCRIPTION
In the NVME charm, when receiving a reply, it's possible that the format may not be as expected, so wrap any attempts to access it in a try/except clause.