### PR TITLE
Misc. improvements to the github workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -70,6 +70,7 @@ jobs:
     strategy:
       matrix:
         part: ${{ fromJson(needs.modifiedparts.outputs.parts) }}
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -98,7 +99,7 @@ jobs:
       - name: Upload built charm
         uses: actions/upload-artifact@v4
         with:
-          name: charm-${{ matrix.part }}
+          name: charms
           path: "./${{ matrix.part }}/*.charm"
 
   functional-test:
@@ -111,11 +112,12 @@ jobs:
     strategy:
       matrix:
         part: ${{ fromJson(needs.modifiedparts.outputs.parts) }}
+      fail-fast: false
     steps:
       - name: Download charm
         uses: actions/download-artifact@v4
         with:
-          name: charm-${{ matrix.part }}
+          name: charms
           path: ~/artifacts/
 
       - name: Checkout code
@@ -152,6 +154,7 @@ jobs:
       - name: Run the tests
         run: |
           date
+          ~/actionutils.sh cacheimgs "ubuntu:24.04"
           mv ~/artifacts/*.charm ./
           if [[ -f "./${{ matrix.part }}/src/tox.ini" ]]; then
             tox -c ${{ matrix.part }}/src -e func-target -- noble-caracal

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Upload built charm
         uses: actions/upload-artifact@v4
         with:
-          name: charms
+          name: charm-artifact-${{ matrix.part }}
           path: "./${{ matrix.part }}/*.charm"
 
   functional-test:
@@ -117,7 +117,9 @@ jobs:
       - name: Download charm
         uses: actions/download-artifact@v4
         with:
-          name: charms
+          name: charm-artifact-${{ matrix.part }}
+          pattern: charm-artifact-*
+          merge-multiple: true
           path: ~/artifacts/
 
       - name: Checkout code

--- a/tests/scripts/actionutils.sh
+++ b/tests/scripts/actionutils.sh
@@ -9,6 +9,16 @@ function cleaript() {
 
 }
 
+function cacheimgs() {
+    lxc launch $1 ctemp 2>&1 >/dev/null
+    lxc launch $1 vmtemp --vm -c limits.cpu=2 -c limits.memory=4GiB -d root,size=25GiB 2>&1 >/dev/null
+    lxc stop ctemp
+    lxc delete ctemp
+    sleep 60
+    lxc stop vmtemp
+    lxc delete vmtemp
+}
+
 run="${1}"
 shift
 


### PR DESCRIPTION
This PR makes it so that:
- A single failure in a test run doesn't automatically cancel all the other test runs.
- The upload task has been modified so that the name is equal for all jobs. This was necessary because otherwise the charms would only download their own built files.
- Before deploying via juju for the functional testing, the images for both containers and VM's are cached.