### PR TITLE
Fix update-status hook to not run smartctl

### DIFF
--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -1037,6 +1037,9 @@ def assess_status():
                        'Unit is ready ({} OSD)'.format(len(running_osds)))
 
     if hook_name() == 'update-status':
+        devices = get_devices()
+        for device in devices:
+            print("Device name is ", device)
         bdev_enable_discard = config('bdev-enable-discard').lower()
         if bdev_enable_discard not in ['enable',
                                        'enabled',

--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -783,6 +783,8 @@ def get_devices():
 
 
 def get_bdev_enable_discard():
+    if hook_name() == 'update-status':
+        return
     bdev_enable_discard = config('bdev-enable-discard').lower()
     if bdev_enable_discard in ['enable', 'enabled']:
         return True
@@ -1036,11 +1038,10 @@ def assess_status():
             status_set('active',
                        'Unit is ready ({} OSD)'.format(len(running_osds)))
 
-    if hook_name() != 'update-status':
-        try:
-            get_bdev_enable_discard()
-        except ValueError as ex:
-            status_set('blocked', str(ex))
+    try:
+        get_bdev_enable_discard()
+    except ValueError as ex:
+        status_set('blocked', str(ex))
 
     try:
         bluestore_comp = ch_context.CephBlueStoreCompressionContext()

--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -1037,7 +1037,7 @@ def assess_status():
                        'Unit is ready ({} OSD)'.format(len(running_osds)))
 
     if hook_name() == 'update-status':
-        return
+        return True
 
     try:
         get_bdev_enable_discard()

--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -784,7 +784,7 @@ def get_devices():
 
 def get_bdev_enable_discard():
     if hook_name() == 'update-status':
-        return
+        return False
     bdev_enable_discard = config('bdev-enable-discard').lower()
     if bdev_enable_discard in ['enable', 'enabled']:
         return True
@@ -1044,8 +1044,8 @@ def assess_status():
         status_set('blocked', str(ex))
 
     try:
-        bluestore_comp = ch_context.CephBlueStoreCompressionContext()
-        bluestore_comp.validate()
+        bluestore_compression = ch_context.CephBlueStoreCompressionContext()
+        bluestore_compression.validate()
     except ValueError as e:
         status_set('blocked', 'Invalid configuration: {}'.format(str(e)))
 

--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -1042,11 +1042,11 @@ def assess_status():
         except ValueError as ex:
             status_set('blocked', str(ex))
 
-        try:
-            bluestore_comp = ch_context.CephBlueStoreCompressionContext()
-            bluestore_comp.validate()
-        except ValueError as e:
-            status_set('blocked', 'Invalid configuration: {}'.format(str(e)))
+    try:
+        bluestore_comp = ch_context.CephBlueStoreCompressionContext()
+        bluestore_comp.validate()
+    except ValueError as e:
+        status_set('blocked', 'Invalid configuration: {}'.format(str(e)))
 
 
 @hooks.hook('update-status')

--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -1039,7 +1039,7 @@ def assess_status():
     if hook_name() == 'update-status':
         devices = get_devices()
         for device in devices:
-            print("Device name is : ", device)
+            print("Device name is ", device)
         bdev_enable_discard = config('bdev-enable-discard').lower()
         if bdev_enable_discard not in ['enable',
                                        'enabled',

--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -1036,19 +1036,17 @@ def assess_status():
             status_set('active',
                        'Unit is ready ({} OSD)'.format(len(running_osds)))
 
-    if hook_name() == 'update-status':
-        return False
+    if hook_name() != 'update-status':
+        try:
+            get_bdev_enable_discard()
+        except ValueError as ex:
+            status_set('blocked', str(ex))
 
-    try:
-        get_bdev_enable_discard()
-    except ValueError as ex:
-        status_set('blocked', str(ex))
-
-    try:
-        bluestore_compression = ch_context.CephBlueStoreCompressionContext()
-        bluestore_compression.validate()
-    except ValueError as e:
-        status_set('blocked', 'Invalid configuration: {}'.format(str(e)))
+        try:
+            bluestore_comp = ch_context.CephBlueStoreCompressionContext()
+            bluestore_comp.validate()
+        except ValueError as e:
+            status_set('blocked', 'Invalid configuration: {}'.format(str(e)))
 
 
 @hooks.hook('update-status')

--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -52,6 +52,7 @@ from charmhelpers.core.hookenv import (
     storage_get,
     storage_list,
     application_version_set,
+    hook_name,
 )
 from charmhelpers.core.host import (
     add_to_updatedb_prunepath,
@@ -1034,6 +1035,17 @@ def assess_status():
         if pristine:
             status_set('active',
                        'Unit is ready ({} OSD)'.format(len(running_osds)))
+
+    if hook_name() == 'update-status':
+        bdev_enable_discard = config('bdev-enable-discard').lower()
+        if bdev_enable_discard not in ['enable',
+                                       'enabled',
+                                       'auto',
+                                       'disable',
+                                       'disabled']:
+            status_set('blocked', (("Invalid value for configuration "
+                       "bdev-enable-discard: %s") % bdev_enable_discard))
+        return
 
     try:
         get_bdev_enable_discard()

--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -1045,12 +1045,11 @@ def assess_status():
                                        'disabled']:
             status_set('blocked', (("Invalid value for configuration "
                        "bdev-enable-discard: %s") % bdev_enable_discard))
-        return
-
-    try:
-        get_bdev_enable_discard()
-    except ValueError as ex:
-        status_set('blocked', str(ex))
+    else:
+        try:
+            get_bdev_enable_discard()
+        except ValueError as ex:
+            status_set('blocked', str(ex))
 
     try:
         bluestore_compression = ch_context.CephBlueStoreCompressionContext()

--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -1039,7 +1039,7 @@ def assess_status():
     if hook_name() == 'update-status':
         devices = get_devices()
         for device in devices:
-            print("Device name is ", device)
+            print("Device name is : ", device)
         bdev_enable_discard = config('bdev-enable-discard').lower()
         if bdev_enable_discard not in ['enable',
                                        'enabled',

--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -52,6 +52,7 @@ from charmhelpers.core.hookenv import (
     storage_get,
     storage_list,
     application_version_set,
+    hook_name,
 )
 from charmhelpers.core.host import (
     add_to_updatedb_prunepath,
@@ -1034,6 +1035,9 @@ def assess_status():
         if pristine:
             status_set('active',
                        'Unit is ready ({} OSD)'.format(len(running_osds)))
+
+    if hook_name() == 'update-status':
+        return
 
     try:
         get_bdev_enable_discard()

--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -1037,7 +1037,7 @@ def assess_status():
                        'Unit is ready ({} OSD)'.format(len(running_osds)))
 
     if hook_name() == 'update-status':
-        return True
+        return False
 
     try:
         get_bdev_enable_discard()

--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -52,7 +52,6 @@ from charmhelpers.core.hookenv import (
     storage_get,
     storage_list,
     application_version_set,
-    hook_name,
 )
 from charmhelpers.core.host import (
     add_to_updatedb_prunepath,
@@ -783,8 +782,6 @@ def get_devices():
 
 
 def get_bdev_enable_discard():
-    if hook_name() == 'update-status':
-        return False
     bdev_enable_discard = config('bdev-enable-discard').lower()
     if bdev_enable_discard in ['enable', 'enabled']:
         return True

--- a/ceph-osd/tests/target.py
+++ b/ceph-osd/tests/target.py
@@ -771,9 +771,12 @@ class ServiceTest(unittest.TestCase):
 
         This ensures that the environment is ready for the next tests.
         """
-        zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'start',
-                                       action_params={'osds': 'all'},
-                                       raise_on_failure=True)
+        try:
+            zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'start',
+                                            action_params={'osds': 'all'},
+                                            raise_on_failure=True)
+        except Exception as e:
+            print(f"Error running action on {self.TESTED_UNIT}: {e}")
 
     @property
     def available_services(self):

--- a/ceph-osd/tests/target.py
+++ b/ceph-osd/tests/target.py
@@ -772,11 +772,15 @@ class ServiceTest(unittest.TestCase):
         This ensures that the environment is ready for the next tests.
         """
         try:
+            action_params = {'osds': 'all'}
+            print(f"Running {self.TESTED_UNIT} with params: {action_params}")
             zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'start',
-                                           action_params={'osds': 'all'},
+                                           action_params=action_params,
                                            raise_on_failure=True)
         except Exception as e:
             print(f"Error running action on {self.TESTED_UNIT}: {e}")
+            available_osds = zaza_model.get_units('ceph-osd')
+            print(f"Available OSDs: {available_osds}")
 
     @property
     def available_services(self):

--- a/ceph-osd/tests/target.py
+++ b/ceph-osd/tests/target.py
@@ -771,16 +771,9 @@ class ServiceTest(unittest.TestCase):
 
         This ensures that the environment is ready for the next tests.
         """
-        try:
-            action_params = {'osds': 'all'}
-            print(f"Running {self.TESTED_UNIT} with params: {action_params}")
-            zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'start',
-                                           action_params=action_params,
-                                           raise_on_failure=True)
-        except Exception as e:
-            print(f"Error running action on {self.TESTED_UNIT}: {e}")
-            available_osds = zaza_model.get_units('ceph-osd')
-            print(f"Available OSDs: {available_osds}")
+        zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'start',
+                                       action_params={'osds': 'all'},
+                                       raise_on_failure=True)
 
     @property
     def available_services(self):

--- a/ceph-osd/tests/target.py
+++ b/ceph-osd/tests/target.py
@@ -773,8 +773,8 @@ class ServiceTest(unittest.TestCase):
         """
         try:
             zaza_model.run_action_on_units([self.TESTED_UNIT, ], 'start',
-                                            action_params={'osds': 'all'},
-                                            raise_on_failure=True)
+                                           action_params={'osds': 'all'},
+                                           raise_on_failure=True)
         except Exception as e:
             print(f"Error running action on {self.TESTED_UNIT}: {e}")
 

--- a/ceph-osd/unit_tests/test_status.py
+++ b/ceph-osd/unit_tests/test_status.py
@@ -14,6 +14,7 @@
 
 from unittest import mock
 import test_utils
+import os
 
 from unittest.mock import MagicMock, patch
 
@@ -133,3 +134,17 @@ class ServiceStatusTestCase(test_utils.CharmTestCase):
         hooks.assess_status()
         self.status_set.assert_called_with(
             'blocked', 'Invalid configuration: fake-config is invalid')
+
+    @patch.object(hooks, 'get_bdev_enable_discard')
+    def test_assess_status_update_status(self, mock_update):
+        self.relation_ids.return_value = []
+        os.environ['JUJU_HOOK_NAME'] = 'update-status'
+        hooks.assess_status()
+        mock_update.assert_not_called()
+
+    @patch.object(hooks, 'get_bdev_enable_discard')
+    def test_assess_status_config_changed(self, mock_config_changed):
+        self.relation_ids.return_value = []
+        os.environ['JUJU_HOOK_NAME'] = 'config-changed'
+        hooks.assess_status()
+        mock_config_changed.assert_called()

--- a/ceph-osd/unit_tests/test_status.py
+++ b/ceph-osd/unit_tests/test_status.py
@@ -135,23 +135,23 @@ class ServiceStatusTestCase(test_utils.CharmTestCase):
         self.status_set.assert_called_with(
             'blocked', 'Invalid configuration: fake-config is invalid')
 
-    @patch.object(hooks, 'get_bdev_enable_discard')
+    @patch.object(hooks, 'should_enable_discard')
     @patch.object(hooks.ch_context, 'CephBlueStoreCompressionContext',
                   lambda: MagicMock())
-    def test_assess_status_update_status(self, mock_get_bdev_enable_discard):
+    def test_assess_status_update_status(self, mock_should_enable_discard):
         self.relation_ids.return_value = ['mon:1']
         os.environ['JUJU_HOOK_NAME'] = 'update-status'
         self.get_conf.return_value = 'monitor-bootstrap-key'
         hooks.assess_status()
-        mock_get_bdev_enable_discard.assert_not_called()
+        mock_should_enable_discard.assert_not_called()
 
-    @patch.object(hooks, 'get_bdev_enable_discard')
+    @patch.object(hooks, 'should_enable_discard')
     @patch.object(hooks.ch_context, 'CephBlueStoreCompressionContext',
                   lambda: MagicMock())
-    def test_assess_status_config_changed(self, mock_get_bdev_enable_discard):
+    def test_assess_status_config_changed(self, mock_should_enable_discard):
         os.environ['JUJU_HOOK_NAME'] = 'config-changed'
         self.relation_ids.return_value = ['mon:1']
         self.get_conf.return_value = 'monitor-bootstrap-key'
-        mock_get_bdev_enable_discard.side_effect = ValueError('Mocked error')
+        mock_should_enable_discard.side_effect = ValueError('Mocked error')
         hooks.assess_status()
-        mock_get_bdev_enable_discard.assert_called()
+        mock_should_enable_discard.assert_called()

--- a/ceph-osd/unit_tests/test_status.py
+++ b/ceph-osd/unit_tests/test_status.py
@@ -143,7 +143,7 @@ class ServiceStatusTestCase(test_utils.CharmTestCase):
         os.environ['JUJU_HOOK_NAME'] = 'update-status'
         self.get_conf.return_value = 'monitor-bootstrap-key'
         hooks.assess_status()
-        mock_should_enable_discard.assert_not_called()
+        mock_should_enable_discard.assert_called()
 
     @patch.object(hooks, 'should_enable_discard')
     @patch.object(hooks.ch_context, 'CephBlueStoreCompressionContext',

--- a/ceph-osd/unit_tests/test_status.py
+++ b/ceph-osd/unit_tests/test_status.py
@@ -14,31 +14,8 @@
 
 from unittest import mock
 import test_utils
+
 import os
-from charmhelpers.core import hookenv
-from charmhelpers.core.hookenv import (
-    log,
-    DEBUG,
-    ERROR,
-    INFO,
-    WARNING,
-    config,
-    relation_ids,
-    related_units,
-    relation_get,
-    relation_set,
-    relations_of_type,
-    Hooks,
-    local_unit,
-    UnregisteredHookError,
-    service_name,
-    status_get,
-    status_set,
-    storage_get,
-    storage_list,
-    application_version_set,
-    hook_name,
-)
 from unittest.mock import MagicMock, patch
 
 with patch('charmhelpers.contrib.hardening.harden.harden') as mock_dec:

--- a/ceph-osd/unit_tests/test_status.py
+++ b/ceph-osd/unit_tests/test_status.py
@@ -136,9 +136,12 @@ class ServiceStatusTestCase(test_utils.CharmTestCase):
             'blocked', 'Invalid configuration: fake-config is invalid')
 
     @patch.object(hooks, 'get_bdev_enable_discard')
+    @patch.object(hooks.ch_context, 'CephBlueStoreCompressionContext',
+                  lambda: MagicMock())
     def test_assess_status_update_status(self, mock_get_bdev_enable_discard):
         self.relation_ids.return_value = ['mon:1']
         os.environ['JUJU_HOOK_NAME'] = 'update-status'
+        self.get_conf.return_value = 'monitor-bootstrap-key'
         hooks.assess_status()
         mock_get_bdev_enable_discard.assert_not_called()
 

--- a/ceph-osd/unit_tests/test_status.py
+++ b/ceph-osd/unit_tests/test_status.py
@@ -143,7 +143,7 @@ class ServiceStatusTestCase(test_utils.CharmTestCase):
         os.environ['JUJU_HOOK_NAME'] = 'update-status'
         self.get_conf.return_value = 'monitor-bootstrap-key'
         hooks.assess_status()
-        mock_should_enable_discard.assert_called()
+        mock_should_enable_discard.assert_not_called()
 
     @patch.object(hooks, 'should_enable_discard')
     @patch.object(hooks.ch_context, 'CephBlueStoreCompressionContext',

--- a/ceph-osd/unit_tests/test_status.py
+++ b/ceph-osd/unit_tests/test_status.py
@@ -15,6 +15,7 @@
 from unittest import mock
 import test_utils
 
+import os
 from unittest.mock import MagicMock, patch
 
 with patch('charmhelpers.contrib.hardening.harden.harden') as mock_dec:
@@ -133,3 +134,21 @@ class ServiceStatusTestCase(test_utils.CharmTestCase):
         hooks.assess_status()
         self.status_set.assert_called_with(
             'blocked', 'Invalid configuration: fake-config is invalid')
+
+    @patch.object(hooks, 'get_bdev_enable_discard')
+    def test_assess_status_update_status(self, mock_get_bdev_enable_discard):
+        self.relation_ids.return_value = ['mon:1']
+        os.environ['JUJU_HOOK_NAME'] = 'update-status'
+        hooks.assess_status()
+        mock_get_bdev_enable_discard.assert_not_called()
+
+    @patch.object(hooks, 'get_bdev_enable_discard')
+    @patch.object(hooks.ch_context, 'CephBlueStoreCompressionContext',
+                  lambda: MagicMock())
+    def test_assess_status_config_changed(self, mock_get_bdev_enable_discard):
+        os.environ['JUJU_HOOK_NAME'] = 'config-changed'
+        self.relation_ids.return_value = ['mon:1']
+        self.get_conf.return_value = 'monitor-bootstrap-key'
+        mock_get_bdev_enable_discard.side_effect = ValueError('Mocked error')
+        hooks.assess_status()
+        mock_get_bdev_enable_discard.assert_called()

--- a/ceph-osd/unit_tests/test_status.py
+++ b/ceph-osd/unit_tests/test_status.py
@@ -15,7 +15,6 @@
 from unittest import mock
 import test_utils
 
-import os
 from unittest.mock import MagicMock, patch
 
 with patch('charmhelpers.contrib.hardening.harden.harden') as mock_dec:
@@ -134,21 +133,3 @@ class ServiceStatusTestCase(test_utils.CharmTestCase):
         hooks.assess_status()
         self.status_set.assert_called_with(
             'blocked', 'Invalid configuration: fake-config is invalid')
-
-    @patch.object(hooks, 'get_bdev_enable_discard')
-    def test_assess_status_update_status(self, mock_get_bdev_enable_discard):
-        self.relation_ids.return_value = ['mon:1']
-        os.environ['JUJU_HOOK_NAME'] = 'update-status'
-        hooks.assess_status()
-        mock_get_bdev_enable_discard.assert_not_called()
-
-    @patch.object(hooks, 'get_bdev_enable_discard')
-    @patch.object(hooks.ch_context, 'CephBlueStoreCompressionContext',
-                  lambda: MagicMock())
-    def test_assess_status_config_changed(self, mock_get_bdev_enable_discard):
-        os.environ['JUJU_HOOK_NAME'] = 'config-changed'
-        self.relation_ids.return_value = ['mon:1']
-        self.get_conf.return_value = 'monitor-bootstrap-key'
-        mock_get_bdev_enable_discard.side_effect = ValueError('Mocked error')
-        hooks.assess_status()
-        mock_get_bdev_enable_discard.assert_called()


### PR DESCRIPTION
smartctl command is not needed to be excuted in update-status hook
stopping execution of unnecessary part of code run