### PR TITLE
Add Terraform modules for ceph-mon and ceph-osd

### DIFF
--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -54,6 +54,20 @@ jobs:
       working-directory: ${{env.WORKING_DIR}}
     - run: terraform show tfplan
       working-directory: ${{env.WORKING_DIR}}
+    - run: |
+        terraform apply -auto-approve
+        for i in {1..30}; do
+          if juju status --format=json | jq -e '.applications | all(.status.current == "active")' >/dev/null; then
+          echo "All applications are active"
+          exit 0
+          fi
+          juju status
+          echo "Waiting for applications to become active..."
+          sleep 10
+        done
+        echo "Timeout waiting for applications to become active"
+        exit 1
+      working-directory: ${{env.WORKING_DIR}}
     - uses: actions/upload-artifact@v4
       with:
         name: ${{matrix.test.name}}-terraform-plan

--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -55,6 +55,7 @@ jobs:
     - run: terraform show tfplan
       working-directory: ${{env.WORKING_DIR}}
     - run: |
+        juju add-model test
         terraform apply -auto-approve
         for i in {1..30}; do
           if juju status --format=json | jq -e '.applications | all(.status.current == "active")' >/dev/null; then

--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -58,7 +58,7 @@ jobs:
         juju add-model test
         terraform apply -auto-approve
         for i in {1..30}; do
-          if juju status --format=json | jq -e '.applications | all(.status.current == "active")'; then
+          if juju status --format=json | jq -e '.applications | all(.application-status.current == "active")'; then
           echo "All applications are active"
           exit 0
           fi

--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -58,7 +58,7 @@ jobs:
         juju add-model test
         terraform apply -auto-approve
         for i in {1..30}; do
-          if juju status --format=json | jq -e '.applications | all(.status.current == "active")' >/dev/null; then
+          if juju status --format=json | jq -e '.applications | all(.status.current == "active")'; then
           echo "All applications are active"
           exit 0
           fi

--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       TF_VAR_model: test
       TF_VAR_manifest_yaml: ${{ matrix.test.yaml }}
+      WORKING_DIR: 'terraform'
     steps:
     - uses: actions/checkout@v4
     - name: Install Python
@@ -48,12 +49,12 @@ jobs:
         } >> "$GITHUB_ENV"
     - uses: hashicorp/setup-terraform@v3
     - run: terraform init
-      working-directory: ${{github.WORKSPACE}}
+      working-directory: ${{env.WORKING_DIR}}
     - run: terraform plan -out=tfplan
-      working-directory: ${{github.WORKSPACE}}
+      working-directory: ${{env.WORKING_DIR}}
     - run: terraform show tfplan
-      working-directory: ${{github.WORKSPACE}}
+      working-directory: ${{env.WORKING_DIR}}
     - uses: actions/upload-artifact@v4
       with:
         name: ${{matrix.test.name}}-terraform-plan
-        path: ${{github.WORKSPACE}}/tfplan
+        path: ${{env.WORKING_DIR}}/tfplan

--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -1,0 +1,59 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: Plan Terraform tests
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+
+jobs:
+  plan-terraform:
+    name: Plan Terraform with Juju
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test:
+        - name: default
+          yaml: test/default.yaml
+    env:
+      TF_VAR_model: test
+      TF_VAR_manifest_yaml: ${{ matrix.test.yaml }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - uses: charmed-kubernetes/actions-operator@main
+      with:
+        provider: lxd
+        channel: latest/stable
+    - name: Prepare juju tf provider environment
+      run: |
+        CONTROLLER=$(juju whoami | yq .Controller)
+        JUJU_CONTROLLER_ADDRESSES="$(juju show-controller | yq '.[$CONTROLLER]'.details.\"api-endpoints\" | tr -d "[]' "|tr -d '"'|tr -d '\n')"
+        JUJU_USERNAME="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.user|tr -d '"')"
+        JUJU_PASSWORD="$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password|tr -d '"')"
+
+        echo "JUJU_CONTROLLER_ADDRESSES=$JUJU_CONTROLLER_ADDRESSES" >> "$GITHUB_ENV"
+        echo "JUJU_USERNAME=$JUJU_USERNAME" >> "$GITHUB_ENV"
+        echo "JUJU_PASSWORD=$JUJU_PASSWORD" >> "$GITHUB_ENV"
+        {
+          echo 'JUJU_CA_CERT<<EOF'
+          juju show-controller $(echo $CONTROLLER|tr -d '"') | yq '.[$CONTROLLER]'.details.\"ca-cert\"|tr -d '"'
+          echo EOF
+        } >> "$GITHUB_ENV"
+    - uses: hashicorp/setup-terraform@v3
+    - run: terraform init
+      working-directory: ${{github.WORKSPACE}}
+    - run: terraform plan -out=tfplan
+      working-directory: ${{github.WORKSPACE}}
+    - run: terraform show tfplan
+      working-directory: ${{github.WORKSPACE}}
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ${{matrix.test.name}}-terraform-plan
+        path: ${{github.WORKSPACE}}/tfplan

--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -56,17 +56,30 @@ jobs:
       working-directory: ${{env.WORKING_DIR}}
     - run: |
         juju add-model test
-        terraform apply -auto-approve
-        for i in {1..30}; do
-          if juju status --format=json | jq -e '.applications | all(.application-status.current == "active")'; then
-          echo "All applications are active"
-          exit 0
+        set -e  # Exit on error
+
+        # Apply Terraform changes
+        terraform apply -auto-approve || { echo "Terraform apply failed"; exit 1; }
+
+        # Wait for Juju applications to become active
+        MAX_RETRIES=30
+        for i in $(seq 1 $MAX_RETRIES); do
+          echo "Checking Juju application statuses... Attempt $i/$MAX_RETRIES"
+
+          # Fetch status JSON once and store it
+          STATUS_JSON=$(juju status --format=json)
+
+          # Check if all applications are active
+          if echo "$STATUS_JSON" | jq -e '.applications | all(.["application-status"].current == "active")' > /dev/null; then
+            echo "✅ All applications are active"
+            exit 0
           fi
-          juju status --format=json | jq -e '.applications'
-          echo "Waiting for applications to become active..."
+
+          echo "⏳ Waiting for applications to become active..."
           sleep 10
         done
-        echo "Timeout waiting for applications to become active"
+
+        echo "❌ Timeout waiting for applications to become active"
         exit 1
       working-directory: ${{env.WORKING_DIR}}
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -62,7 +62,7 @@ jobs:
           echo "All applications are active"
           exit 0
           fi
-          juju status --format=json | jq -e '.applications
+          juju status --format=json | jq -e '.applications'
           echo "Waiting for applications to become active..."
           sleep 10
         done

--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         test:
         - name: default
-          yaml: test/default.yaml
+          yaml: ../tests/terraform/default.yaml
     env:
       TF_VAR_model: test
       TF_VAR_manifest_yaml: ${{ matrix.test.yaml }}

--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -62,7 +62,7 @@ jobs:
           echo "All applications are active"
           exit 0
           fi
-          juju status
+          juju status --format=json | jq -e '.applications
           echo "Waiting for applications to become active..."
           sleep 10
         done

--- a/ceph-mon/terraform/README.md
+++ b/ceph-mon/terraform/README.md
@@ -1,0 +1,96 @@
+# Terraform Manifest Module
+
+This module reads a yaml configuration file and exports the values into terraform variables that
+can be passed down into other modules. It is specifically tailored for working with
+modules for charms defined with the
+[juju terraform provider](https://registry.terraform.io/providers/juju/juju/latest/docs). It
+simplifies having to pass every individual charm input as a variable in the product level
+module for a given product.
+
+## Inputs
+
+| Name       | Type   | Description                                                            | Required |
+|------------|--------|------------------------------------------------------------------------|----------|
+| `manifest` | string | Absolute path to the yaml file with the config for a Juju application. | true     |
+| `app`      | string | Name of the application to load the config for.                        | true     |
+
+## Outputs
+
+All outputs are under `config` as a map of values below:
+
+| Name          | Description                                                                   |
+|---------------|-------------------------------------------------------------------------------|
+| `app_name`    | Name of the application in Juju.                                              |
+| `base`        | Base to deploy the charm as eg. ubuntu@24.04.                                 |
+| `channel`     | Channel of the application being deployed.                                    |
+| `config`      | Map of the config for the charm, values can be found under the specific charm |
+| `constraints` | String of constraints when deploying the charm `cores=2 mem=4069M`            |
+| `resources`   | List of resources to deploy with the charm.                                   |
+| `revision`    | Specific revision of this charm to deploy.                                    |
+| `units`       | Number of units of a charm to deploy                                          |
+| `storage`     | Storage configuration of a charm to deploy                                    |
+
+## Usage
+
+This module is meant to be use as a helper for product modules. It is meant to allow the
+user to have one manifest yaml file that can allow hold all the configuration for a solution
+or deployment while also allowing the developer to not have to maintain the configuration
+between each charm and the overall product.
+
+### Defining a `manifest` in terraform
+
+The manifest module will have to be defined for each charm in question. Terraform will
+load the config under the app key and output the values. If the key is not found in the
+manifest, then the module will return `null` and terraform will ignore the configuration.
+
+```
+module "ceph_mon_config" {
+  source = "git::https://github.com/canonical/k8s-bundles//terraform/manifest?ref=main"
+  manifest = var.manifest_yaml
+  app = "ceph_mon"
+}
+```
+
+These values can the be passed into a resource for a specific charm:
+
+```
+module "ceph_mon" {
+  source      = "git::https://github.com/canonical/ceph-charms//ceph-osd/terraform?ref=main"
+  app_name    = module.ceph_mon_config.config.app_name
+  channel     = module.ceph_mon_config.config.channel
+  config      = module.ceph_mon_config.config.config
+  constraints = module.ceph_mon_config.config.constraints
+  model       = var.model
+  resources   = module.ceph_mon_config.config.resources
+  revision    = module.ceph_mon_config.config.revision
+  base        = module.ceph_mon_config.config.base
+  units       = module.ceph_mon_config.config.units
+}
+```
+
+### Defining a manifest.yaml
+
+In the implementation of the product module, the user can specify their configuration using
+a single manifest file similar to the one below:
+
+``` yaml
+ceph_mon:
+    channel: quincy/stable
+    constraints: cores=2 mem=4G root-disk=16G
+    num_units: 1
+    config:
+        monitor-count: 1
+        expected-osd-count: 2
+ceph_osd:
+    channel: quincy/stable
+    constraints: cores=2 mem=4G root-disk=16G
+    num_units: 2
+    storage:
+        [
+            { type: "osd-devices", count: 1, size: "1G" },
+            { type: "osd-journals", count: 1, size: "1G" },
+        ]
+```
+
+Using the terraform in the above section, the `units`, `base`, `constraints`, and `channel`
+forward into the `ceph-mon` deployment.

--- a/ceph-mon/terraform/README.md
+++ b/ceph-mon/terraform/README.md
@@ -76,20 +76,18 @@ a single manifest file similar to the one below:
 ``` yaml
 ceph_mon:
     channel: quincy/stable
-    constraints: cores=2 mem=4G root-disk=16G
-    num_units: 1
+    constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M virt-type=virtual-machine
+    units: 1
     config:
         monitor-count: 1
         expected-osd-count: 2
 ceph_osd:
     channel: quincy/stable
-    constraints: cores=2 mem=4G root-disk=16G
-    num_units: 2
+    constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M virt-type=virtual-machine
+    units: 2
     storage:
-        [
-            { type: "osd-devices", count: 1, size: "1G" },
-            { type: "osd-journals", count: 1, size: "1G" },
-        ]
+        osd-devices: 1G,1
+        osd-journals: 1G,1
 ```
 
 Using the terraform in the above section, the `units`, `base`, `constraints`, and `channel`

--- a/ceph-mon/terraform/main.tf
+++ b/ceph-mon/terraform/main.tf
@@ -1,0 +1,19 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "ceph_mon" {
+  name  = var.app_name
+  model = var.model
+
+  charm {
+    name     = "ceph-mon"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  units       = var.units
+  resources   = var.resources
+}

--- a/ceph-mon/terraform/outputs.tf
+++ b/ceph-mon/terraform/outputs.tf
@@ -1,0 +1,14 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.ceph_mon.name
+}
+
+output "provides" {
+  value = {
+    osd    = "osd"
+    client = "client"
+  }
+}

--- a/ceph-mon/terraform/variables.tf
+++ b/ceph-mon/terraform/variables.tf
@@ -1,0 +1,55 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "ceph-mon"
+}
+
+variable "base" {
+  description = "Ubuntu bases to deploy the charm onto"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying a charm."
+  type        = string
+  default     = "squid/beta"
+}
+
+variable "resources" {
+  description = "Resources to use with the application."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Revision number of the charm"
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units to deploy"
+  type        = number
+  default     = 1
+}
+
+variable "config" {
+  description = "Application config. Details about available options can be found at https://charmhub.io/ceph-mon/configurations."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "model" {
+  description = "Reference to a `juju_model`."
+  type        = string
+}

--- a/ceph-mon/terraform/versions.tf
+++ b/ceph-mon/terraform/versions.tf
@@ -1,0 +1,12 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/ceph-osd/terraform/README.md
+++ b/ceph-osd/terraform/README.md
@@ -76,20 +76,18 @@ a single manifest file similar to the one below:
 ``` yaml
 ceph_mon:
     channel: quincy/stable
-    constraints: cores=2 mem=4G root-disk=16G
-    num_units: 1
+    constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M virt-type=virtual-machine
+    units: 1
     config:
         monitor-count: 1
         expected-osd-count: 2
 ceph_osd:
     channel: quincy/stable
-    constraints: cores=2 mem=4G root-disk=16G
-    num_units: 2
+    constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M virt-type=virtual-machine
+    units: 2
     storage:
-        [
-            { type: "osd-devices", count: 1, size: "1G" },
-            { type: "osd-journals", count: 1, size: "1G" },
-        ]
+        osd-devices: 1G,1
+        osd-journals: 1G,1
 ```
 
 Using the terraform in the above section, the `units`, `base`, `constraints`, and `channel`

--- a/ceph-osd/terraform/README.md
+++ b/ceph-osd/terraform/README.md
@@ -1,0 +1,96 @@
+# Terraform Manifest Module
+
+This module reads a yaml configuration file and exports the values into terraform variables that
+can be passed down into other modules. It is specifically tailored for working with
+modules for charms defined with the
+[juju terraform provider](https://registry.terraform.io/providers/juju/juju/latest/docs). It
+simplifies having to pass every individual charm input as a variable in the product level
+module for a given product.
+
+## Inputs
+
+| Name       | Type   | Description                                                            | Required |
+|------------|--------|------------------------------------------------------------------------|----------|
+| `manifest` | string | Absolute path to the yaml file with the config for a Juju application. | true     |
+| `app`      | string | Name of the application to load the config for.                        | true     |
+
+## Outputs
+
+All outputs are under `config` as a map of values below:
+
+| Name          | Description                                                                   |
+|---------------|-------------------------------------------------------------------------------|
+| `app_name`    | Name of the application in Juju.                                              |
+| `base`        | Base to deploy the charm as eg. ubuntu@24.04.                                 |
+| `channel`     | Channel of the application being deployed.                                    |
+| `config`      | Map of the config for the charm, values can be found under the specific charm |
+| `constraints` | String of constraints when deploying the charm `cores=2 mem=4069M`            |
+| `resources`   | List of resources to deploy with the charm.                                   |
+| `revision`    | Specific revision of this charm to deploy.                                    |
+| `units`       | Number of units of a charm to deploy                                          |
+| `storage`     | Storage configuration of a charm to deploy                                    |
+
+## Usage
+
+This module is meant to be use as a helper for product modules. It is meant to allow the
+user to have one manifest yaml file that can allow hold all the configuration for a solution
+or deployment while also allowing the developer to not have to maintain the configuration
+between each charm and the overall product.
+
+### Defining a `manifest` in terraform
+
+The manifest module will have to be defined for each charm in question. Terraform will
+load the config under the app key and output the values. If the key is not found in the
+manifest, then the module will return `null` and terraform will ignore the configuration.
+
+```
+module "ceph_osd_config" {
+  source = "git::https://github.com/canonical/k8s-bundles//terraform/manifest?ref=main"
+  manifest = var.manifest_yaml
+  app = "ceph_osd"
+}
+```
+
+These values can the be passed into a resource for a specific charm:
+
+```
+module "ceph_osd" {
+  source      = "git::https://github.com/canonical/ceph-charms//ceph-osd/terraform?ref=main"
+  app_name    = module.ceph_osd_config.config.app_name
+  channel     = module.ceph_osd_config.config.channel
+  config      = module.ceph_osd_config.config.config
+  constraints = module.ceph_osd_config.config.constraints
+  model       = var.model
+  resources   = module.ceph_osd_config.config.resources
+  revision    = module.ceph_osd_config.config.revision
+  base        = module.ceph_osd_config.config.base
+  units       = module.ceph_osd_config.config.units
+}
+```
+
+### Defining a manifest.yaml
+
+In the implementation of the product module, the user can specify their configuration using
+a single manifest file similar to the one below:
+
+``` yaml
+ceph_mon:
+    channel: quincy/stable
+    constraints: cores=2 mem=4G root-disk=16G
+    num_units: 1
+    config:
+        monitor-count: 1
+        expected-osd-count: 2
+ceph_osd:
+    channel: quincy/stable
+    constraints: cores=2 mem=4G root-disk=16G
+    num_units: 2
+    storage:
+        [
+            { type: "osd-devices", count: 1, size: "1G" },
+            { type: "osd-journals", count: 1, size: "1G" },
+        ]
+```
+
+Using the terraform in the above section, the `units`, `base`, `constraints`, and `channel`
+forward into the `ceph-osd` deployment.

--- a/ceph-osd/terraform/main.tf
+++ b/ceph-osd/terraform/main.tf
@@ -1,0 +1,20 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "ceph_osd" {
+  name  = var.app_name
+  model = var.model
+
+  charm {
+    name     = "ceph-osd"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config             = var.config
+  constraints        = var.constraints
+  units              = var.units
+  resources          = var.resources
+  storage_directives = var.storage
+}

--- a/ceph-osd/terraform/outputs.tf
+++ b/ceph-osd/terraform/outputs.tf
@@ -1,0 +1,13 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "app_name" {
+  description = "Name of the deployed application."
+  value       = juju_application.ceph_osd.name
+}
+
+output "requires" {
+  value = {
+    mon = "mon"
+  }
+}

--- a/ceph-osd/terraform/variables.tf
+++ b/ceph-osd/terraform/variables.tf
@@ -1,0 +1,61 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "ceph-osd"
+}
+
+variable "base" {
+  description = "Ubuntu bases to deploy the charm onto"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying a charm."
+  type        = string
+  default     = "squid/beta"
+}
+
+variable "resources" {
+  description = "Resources to use with the application."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Revision number of the charm"
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units to deploy"
+  type        = number
+  default     = 1
+}
+
+variable "config" {
+  description = "Application config. Details about available options can be found at https://charmhub.io/ceph-osd/configurations."
+  type        = map(string)
+  default     = {}
+}
+
+variable "storage" {
+  description = "Storage configuration for this application."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = "arch=amd64"
+}
+
+variable "model" {
+  description = "Reference to a `juju_model`."
+  type        = string
+}

--- a/ceph-osd/terraform/versions.tf
+++ b/ceph-osd/terraform/versions.tf
@@ -1,0 +1,13 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/terraform/applications.tf
+++ b/terraform/applications.tf
@@ -1,0 +1,31 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+module "ceph_mon" {
+  source = "./ceph_mon"
+
+  model       = var.model
+  base        = coalesce(module.ceph_mon_config.config.base, var.k8s.config.base)
+  constraints = coalesce(module.ceph_mon_config.config.constraints, var.k8s.config.constraints)
+  channel     = coalesce(module.ceph_mon_config.config.channel, var.k8s.config.channel)
+
+  config    = coalesce(module.ceph_mon_config.config.config, {})
+  resources = module.ceph_mon_config.config.resources
+  revision  = module.ceph_mon_config.config.revision
+  units     = module.ceph_mon_config.config.units
+}
+
+module "ceph_osd" {
+  source = "./ceph_osd"
+
+  model       = var.model
+  base        = coalesce(module.ceph_osd_config.config.base, var.k8s.config.base)
+  constraints = coalesce(module.ceph_osd_config.config.constraints, var.k8s.config.constraints)
+  channel     = coalesce(module.ceph_osd_config.config.channel, var.k8s.config.channel)
+
+  config    = coalesce(module.ceph_osd_config.config.config, {})
+  resources = module.ceph_osd_config.config.resources
+  storage   = coalesce(module.ceph_osd_config.config.storage, {})
+  revision  = module.ceph_osd_config.config.revision
+  units     = module.ceph_osd_config.config.units
+}

--- a/terraform/applications.tf
+++ b/terraform/applications.tf
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 module "ceph_mon" {
-  source = "./ceph_mon"
+  source = "../ceph-mon/terraform"
 
   model       = var.model
   base        = coalesce(module.ceph_mon_config.config.base, var.k8s.config.base)
@@ -16,7 +16,7 @@ module "ceph_mon" {
 }
 
 module "ceph_osd" {
-  source = "./ceph_osd"
+  source = "../ceph-osd/terraform"
 
   model       = var.model
   base        = coalesce(module.ceph_osd_config.config.base, var.k8s.config.base)

--- a/terraform/applications.tf
+++ b/terraform/applications.tf
@@ -5,11 +5,11 @@ module "ceph_mon" {
   source = "../ceph-mon/terraform"
 
   model       = var.model
-  base        = coalesce(module.ceph_mon_config.config.base, var.k8s.config.base)
-  constraints = coalesce(module.ceph_mon_config.config.constraints, var.k8s.config.constraints)
-  channel     = coalesce(module.ceph_mon_config.config.channel, var.k8s.config.channel)
+  base        = module.ceph_mon_config.config.base
+  constraints = module.ceph_mon_config.config.constraints
+  channel     = module.ceph_mon_config.config.channel
 
-  config    = coalesce(module.ceph_mon_config.config.config, {})
+  config    = module.ceph_mon_config.config.config
   resources = module.ceph_mon_config.config.resources
   revision  = module.ceph_mon_config.config.revision
   units     = module.ceph_mon_config.config.units
@@ -19,13 +19,13 @@ module "ceph_osd" {
   source = "../ceph-osd/terraform"
 
   model       = var.model
-  base        = coalesce(module.ceph_osd_config.config.base, var.k8s.config.base)
-  constraints = coalesce(module.ceph_osd_config.config.constraints, var.k8s.config.constraints)
-  channel     = coalesce(module.ceph_osd_config.config.channel, var.k8s.config.channel)
+  base        = module.ceph_osd_config.config.base
+  constraints = module.ceph_osd_config.config.constraints
+  channel     = module.ceph_osd_config.config.channel
 
-  config    = coalesce(module.ceph_osd_config.config.config, {})
+  config    = module.ceph_osd_config.config.config
   resources = module.ceph_osd_config.config.resources
-  storage   = coalesce(module.ceph_osd_config.config.storage, {})
+  storage   = module.ceph_osd_config.config.storage
   revision  = module.ceph_osd_config.config.revision
   units     = module.ceph_osd_config.config.units
 }

--- a/terraform/configs.tf
+++ b/terraform/configs.tf
@@ -2,13 +2,13 @@
 # See LICENSE file for licensing details.
 
 module "ceph_mon_config" {
-  source   = "../manifest"
+  source   = "./manifest"
   manifest = var.manifest_yaml
   app      = "ceph_mon"
 }
 
 module "ceph_osd_config" {
-  source   = "../manifest"
+  source   = "./manifest"
   manifest = var.manifest_yaml
   app      = "ceph_osd"
 }

--- a/terraform/configs.tf
+++ b/terraform/configs.tf
@@ -1,0 +1,14 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+module "ceph_mon_config" {
+  source   = "../manifest"
+  manifest = var.manifest_yaml
+  app      = "ceph_mon"
+}
+
+module "ceph_osd_config" {
+  source   = "../manifest"
+  manifest = var.manifest_yaml
+  app      = "ceph_osd"
+}

--- a/terraform/integrations.tf
+++ b/terraform/integrations.tf
@@ -1,0 +1,14 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_integration" "ceph_mon" {
+  model = var.model
+  application {
+    name     = module.ceph_mon.app_name
+    endpoint = module.ceph_mon.provides.osd
+  }
+  application {
+    name     = module.ceph_osd.app_name
+    endpoint = module.ceph_osd.requires.mon
+  }
+}

--- a/terraform/manifest/main.tf
+++ b/terraform/manifest/main.tf
@@ -1,0 +1,6 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+locals {
+  yaml_data = lookup(yamldecode(file("${var.manifest}")), var.app, {})
+}

--- a/terraform/manifest/outputs.tf
+++ b/terraform/manifest/outputs.tf
@@ -1,0 +1,16 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "config" {
+  value = {
+    app_name    = lookup(local.yaml_data, "app_name", null)
+    base        = lookup(local.yaml_data, "base", null)
+    channel     = lookup(local.yaml_data, "channel", null)
+    config      = lookup(local.yaml_data, "config", null)
+    constraints = lookup(local.yaml_data, "constraints", null)
+    resources   = lookup(local.yaml_data, "resoruces", null)
+    revision    = lookup(local.yaml_data, "revision", null)
+    units       = lookup(local.yaml_data, "units", null)
+    storage     = lookup(local.yaml_data, "storage", null)
+  }
+}

--- a/terraform/manifest/variables.tf
+++ b/terraform/manifest/variables.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "manifest" {
+  description = "Absolute path to a yaml file with config for a Juju application."
+  type        = string
+}
+
+variable "app" {
+  description = "Name of the application to load config for."
+  type        = string
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,12 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "ceph_mon" {
+  description = "Object of the ceph_mon application."
+  value       = module.ceph_mon
+}
+
+output "ceph_osd" {
+  description = "Object of the ceph_osd application."
+  value       = module.ceph_osd
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,12 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "manifest_yaml" {
+  description = "Absolute path to the manifest yaml file for the charm configurations."
+  type        = string
+}
+
+variable "model" {
+  description = "Name of the Juju model to deploy to."
+  type        = string
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/tests/terraform/default.yaml
+++ b/tests/terraform/default.yaml
@@ -1,0 +1,16 @@
+ceph-mon:
+    channel: quincy/stable
+    constraints: cores=2 mem=4G root-disk=16G
+    num_units: 1
+    config:
+        monitor-count: 1
+        expected-osd-count: 2
+ceph-osd:
+    channel: quincy/stable
+    constraints: cores=2 mem=4G root-disk=16G
+    num_units: 2
+    storage:
+        [
+            { type: "osd-devices", count: 1, size: "1G" },
+            { type: "osd-journals", count: 1, size: "1G" },
+        ]

--- a/tests/terraform/default.yaml
+++ b/tests/terraform/default.yaml
@@ -1,16 +1,14 @@
-ceph-mon:
+ceph_mon:
     channel: quincy/stable
-    constraints: cores=2 mem=4G root-disk=16G
-    num_units: 1
+    constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M virt-type=virtual-machine
+    units: 1
     config:
         monitor-count: 1
         expected-osd-count: 2
-ceph-osd:
+ceph_osd:
     channel: quincy/stable
-    constraints: cores=2 mem=4G root-disk=16G
-    num_units: 2
+    constraints: arch=amd64 cores=2 mem=8192M root-disk=16384M virt-type=virtual-machine
+    units: 2
     storage:
-        [
-            { type: "osd-devices", count: 1, size: "1G" },
-            { type: "osd-journals", count: 1, size: "1G" },
-        ]
+        osd-devices: 1G,1
+        osd-journals: 1G,1

--- a/tests/terraform/main.tf
+++ b/tests/terraform/main.tf
@@ -21,7 +21,7 @@ variable "manifest_yaml" {
 variable "model" {
   description = "Name of the model to deploy to"
   type        = string
-  default     = "my-canonical-k8s"
+  default     = "ceph-model"
 }
 
 module "ceph" {

--- a/tests/terraform/main.tf
+++ b/tests/terraform/main.tf
@@ -1,0 +1,31 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}
+
+provider "juju" {}
+
+variable "manifest_yaml" {
+  description = "Path to the manifest YAML file"
+  type        = string
+}
+
+variable "model" {
+  description = "Name of the model to deploy to"
+  type        = string
+  default     = "my-canonical-k8s"
+}
+
+module "ceph" {
+  source        = "../../terraform"
+  model         = var.model
+  manifest_yaml = var.manifest_yaml
+}


### PR DESCRIPTION
# Summary  

This PR introduces Terraform modules for the `ceph-mon` and `ceph-osd` charms.  

# Rationale  

These Terraform modules were developed as part of Canonical Kubernetes testing efforts to integrate with Ceph. As previously discussed, they are better suited for the ceph charm repository rather than our testing repositories.  

It's important to note that these modules do **not** provide a complete Terraform deployment for Ceph, as they only cover `ceph-mon` and `ceph-osd`.  

# Details  

Each module includes a README with deployment instructions. The setup aligns with SQA’s approach and mirrors existing bundle deployments using `manifest.yaml` files.  

Additionally, a basic GitHub workflow (`plan-terraform`) has been added to validate the modules, ensuring they are correctly structured and deployable via Terraform. However, these tests do **not** confirm a fully functional deployment.  

For [Canonical Kubernetes](https://github.com/canonical/k8s-operator/pull/320), we validate this by deploying a cluster with the Terraform modules and running integration tests against it. This verification is beyond the scope of this PR and will require follow-up work.