### PR TITLE
update-status hook changes

### DIFF
--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -52,6 +52,7 @@ from charmhelpers.core.hookenv import (
     storage_get,
     storage_list,
     application_version_set,
+    hook_name,
 )
 from charmhelpers.core.host import (
     add_to_updatedb_prunepath,
@@ -1035,10 +1036,11 @@ def assess_status():
             status_set('active',
                        'Unit is ready ({} OSD)'.format(len(running_osds)))
 
-    try:
-        get_bdev_enable_discard()
-    except ValueError as ex:
-        status_set('blocked', str(ex))
+    if not hook_name() == 'update-status':
+        try:
+            get_bdev_enable_discard()
+        except ValueError as ex:
+            status_set('blocked', str(ex))
 
     try:
         bluestore_compression = ch_context.CephBlueStoreCompressionContext()

--- a/ceph-osd/hooks/utils.py
+++ b/ceph-osd/hooks/utils.py
@@ -337,11 +337,20 @@ def should_enable_discard(devices):
 
 
 def is_sata30orless(device):
+    db = unitdata.kv()
+    key = '%s_is_sata30orless' % str(device)
+    if db.get(key) is not None:
+        value = db.get(key)
+        log('is_sata30orless: Using cached value %s' % value, level='DEBUG')
+        return value
+
     result = subprocess.check_output(["/usr/sbin/smartctl", "-i", device])
     print(result)
     for line in str(result).split("\\n"):
         if re.match(r"SATA Version is: *SATA (1\.|2\.|3\.0)", str(line)):
+            db.set(key, True)
             return True
+    db.set(key, False)
     return False
 
 


### PR DESCRIPTION
# Description

Smartctl does not need to be run during update-status hook.

Fixes: https://bugs.launchpad.net/charm-ceph-osd/+bug/2040135

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
