### PR TITLE
smartctl changes

### DIFF
--- a/ceph-osd/actions/remove_disk.py
+++ b/ceph-osd/actions/remove_disk.py
@@ -356,6 +356,8 @@ def main():
             charm_devices.remove(action_osd.device)
             if action_osd.alias:
                 aliases.pop(action_osd.alias)
+            key = '%s_is_sata30orless' % str(action_osd.device)
+            kv().unset(key)
             report.update(action_osd.report)
         except RemoveException as e:
             errors.append(str(e))

--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -533,6 +533,12 @@ def get_ceph_context(upgrading=False):
         'bluestore_block_db_size': config('bluestore-block-db-size'),
     }
 
+    devices = get_devices()
+
+    for device in devices:
+        key = '%s_is_sata30orless' % str(device)
+        kv().unset(key)
+
     try:
         cephcontext['bdev_discard'] = get_bdev_enable_discard()
     except ValueError as ex:

--- a/ceph-osd/hooks/utils.py
+++ b/ceph-osd/hooks/utils.py
@@ -337,11 +337,20 @@ def should_enable_discard(devices):
 
 
 def is_sata30orless(device):
+    db = unitdata.kv()
+    key = '%s_is_sata30orless' % str(device)
+    if db.get(key) is not None:
+        value = db.get(key)
+        log('is_sata30orless: Using cached value %s' % value, level='DEBUG')
+        return value
+
     result = subprocess.check_output(["/usr/sbin/smartctl", "-i", device])
     print(result)
     for line in str(result).split("\\n"):
         if re.match(r"SATA Version is: *SATA (1\.|2\.|3\.0)", str(line)):
+            db.set(key, True)
             return True
+    db.set(key, False)
     return False
 
 

--- a/ceph-osd/hooks/utils.py
+++ b/ceph-osd/hooks/utils.py
@@ -339,8 +339,8 @@ def should_enable_discard(devices):
 def is_sata30orless(device):
     db = unitdata.kv()
     key = '%s_is_sata30orless' % str(device)
-    if db.get(key) is not None:
-        value = db.get(key)
+    value = db.get(key)
+    if value is not None:
         log('is_sata30orless: Using cached value %s' % value, level='DEBUG')
         return value
 

--- a/ceph-osd/unit_tests/test_ceph_utils.py
+++ b/ceph-osd/unit_tests/test_ceph_utils.py
@@ -22,6 +22,8 @@ with patch('charmhelpers.contrib.hardening.harden.harden') as mock_dec:
                             lambda *args, **kwargs: f(*args, **kwargs))
     import utils
 
+from charmhelpers.core import unitdata
+
 
 class CephUtilsTestCase(unittest.TestCase):
     def setUp(self):
@@ -92,9 +94,15 @@ class CephUtilsTestCase(unittest.TestCase):
                          b'SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s)\n'
                          b'supressed text\n\n')
         mock_subprocess_check_output.return_value = extcmd_output
-        ret = utils.is_sata30orless('/dev/sda')
-        mock_subprocess_check_output.assert_called()
-        self.assertEqual(ret, False)
+        db = unitdata.kv()
+        key = '/dev/sda_is_sata30orless'
+        if db.get(key) is None:
+            ret = utils.is_sata30orless('/dev/sda')
+            mock_subprocess_check_output.assert_called()
+            self.assertEqual(ret, False)
+        else:
+            ret = utils.is_sata30orless('/dev/sda')
+            mock_subprocess_check_output.assert_not_called()
 
     @patch('subprocess.check_output')
     def test_is_sata30orless_sata30(self, mock_subprocess_check_output):
@@ -102,9 +110,15 @@ class CephUtilsTestCase(unittest.TestCase):
                          b'SATA 3.0, 6.0 Gb/s (current: 6.0 Gb/s)\n'
                          b'supressed text\n\n')
         mock_subprocess_check_output.return_value = extcmd_output
-        ret = utils.is_sata30orless('/dev/sda')
-        mock_subprocess_check_output.assert_called()
-        self.assertEqual(ret, True)
+        db = unitdata.kv()
+        key = '/dev/sda_is_sata30orless'
+        if db.get(key) is None:
+            ret = utils.is_sata30orless('/dev/sda')
+            mock_subprocess_check_output.assert_called()
+            self.assertEqual(ret, True)
+        else:
+            ret = utils.is_sata30orless('/dev/sda')
+            mock_subprocess_check_output.assert_not_called()
 
     @patch('subprocess.check_output')
     def test_is_sata30orless_sata26(self, mock_subprocess_check_output):
@@ -112,9 +126,15 @@ class CephUtilsTestCase(unittest.TestCase):
                          b'SATA 2.6, 3.0 Gb/s (current: 3.0 Gb/s)\n'
                          b'supressed text\n\n')
         mock_subprocess_check_output.return_value = extcmd_output
-        ret = utils.is_sata30orless('/dev/sda')
-        mock_subprocess_check_output.assert_called()
-        self.assertEqual(ret, True)
+        db = unitdata.kv()
+        key = '/dev/sda_is_sata30orless'
+        if db.get(key) is None:
+            ret = utils.is_sata30orless('/dev/sda')
+            mock_subprocess_check_output.assert_called()
+            self.assertEqual(ret, True)
+        else:
+            ret = utils.is_sata30orless('/dev/sda')
+            mock_subprocess_check_output.assert_not_called()
 
     @patch.object(utils, "function_get")
     def test_raise_on_missing_arguments(self, mock_function_get):

--- a/ceph-osd/unit_tests/test_ceph_utils.py
+++ b/ceph-osd/unit_tests/test_ceph_utils.py
@@ -15,14 +15,12 @@
 
 import unittest
 
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 with patch('charmhelpers.contrib.hardening.harden.harden') as mock_dec:
     mock_dec.side_effect = (lambda *dargs, **dkwargs: lambda f:
                             lambda *args, **kwargs: f(*args, **kwargs))
     import utils
-
-from charmhelpers.core import unitdata
 
 
 class CephUtilsTestCase(unittest.TestCase):
@@ -89,49 +87,64 @@ class CephUtilsTestCase(unittest.TestCase):
         self.assertEqual(ret, False)
 
     @patch('subprocess.check_output')
-    def test_is_sata30orless_sata31(self, mock_subprocess_check_output):
+    @patch('charmhelpers.core.unitdata.kv')
+    def test_is_sata30orless_sata31(self, mock_db,
+                                    mock_subprocess_check_output):
         extcmd_output = (b'supressed text\nSATA Version is:  '
                          b'SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s)\n'
                          b'supressed text\n\n')
         mock_subprocess_check_output.return_value = extcmd_output
-        db = unitdata.kv()
+        mock_db_instance = MagicMock()
+        mock_db.return_value = mock_db_instance
         key = '/dev/sda_is_sata30orless'
-        if db.get(key) is None:
+        mock_db_instance.return_value = False
+        if mock_db_instance.get(key) is None:
             ret = utils.is_sata30orless('/dev/sda')
             mock_subprocess_check_output.assert_called()
             self.assertEqual(ret, False)
+            mock_db_instance.set.assert_called_with(key, False)
         else:
             ret = utils.is_sata30orless('/dev/sda')
             mock_subprocess_check_output.assert_not_called()
 
     @patch('subprocess.check_output')
-    def test_is_sata30orless_sata30(self, mock_subprocess_check_output):
+    @patch('charmhelpers.core.unitdata.kv')
+    def test_is_sata30orless_sata30(self, mock_db,
+                                    mock_subprocess_check_output):
         extcmd_output = (b'supressed text\nSATA Version is:  '
                          b'SATA 3.0, 6.0 Gb/s (current: 6.0 Gb/s)\n'
                          b'supressed text\n\n')
         mock_subprocess_check_output.return_value = extcmd_output
-        db = unitdata.kv()
+        mock_db_instance = MagicMock()
+        mock_db.return_value = mock_db_instance
         key = '/dev/sda_is_sata30orless'
-        if db.get(key) is None:
+        mock_db_instance.get.return_value = None
+        if mock_db_instance.get(key) is None:
             ret = utils.is_sata30orless('/dev/sda')
             mock_subprocess_check_output.assert_called()
             self.assertEqual(ret, True)
+            mock_db_instance.set.assert_called_with(key, True)
         else:
             ret = utils.is_sata30orless('/dev/sda')
             mock_subprocess_check_output.assert_not_called()
 
     @patch('subprocess.check_output')
-    def test_is_sata30orless_sata26(self, mock_subprocess_check_output):
+    @patch('charmhelpers.core.unitdata.kv')
+    def test_is_sata30orless_sata26(self, mock_db,
+                                    mock_subprocess_check_output):
         extcmd_output = (b'supressed text\nSATA Version is:  '
                          b'SATA 2.6, 3.0 Gb/s (current: 3.0 Gb/s)\n'
                          b'supressed text\n\n')
         mock_subprocess_check_output.return_value = extcmd_output
-        db = unitdata.kv()
+        mock_db_instance = MagicMock()
+        mock_db.return_value = mock_db_instance
         key = '/dev/sda_is_sata30orless'
-        if db.get(key) is None:
+        mock_db_instance.get.return_value = None
+        if mock_db_instance.get(key) is None:
             ret = utils.is_sata30orless('/dev/sda')
             mock_subprocess_check_output.assert_called()
             self.assertEqual(ret, True)
+            mock_db_instance.set.assert_called_with(key, True)
         else:
             ret = utils.is_sata30orless('/dev/sda')
             mock_subprocess_check_output.assert_not_called()

--- a/ceph-osd/unit_tests/test_ceph_utils.py
+++ b/ceph-osd/unit_tests/test_ceph_utils.py
@@ -94,18 +94,28 @@ class CephUtilsTestCase(unittest.TestCase):
                          b'SATA 3.1, 6.0 Gb/s (current: 6.0 Gb/s)\n'
                          b'supressed text\n\n')
         mock_subprocess_check_output.return_value = extcmd_output
+
         mock_db_instance = MagicMock()
         mock_db.return_value = mock_db_instance
+
         key = '/dev/sda_is_sata30orless'
-        mock_db_instance.return_value = False
-        if mock_db_instance.get(key) is None:
-            ret = utils.is_sata30orless('/dev/sda')
-            mock_subprocess_check_output.assert_called()
-            self.assertEqual(ret, False)
-            mock_db_instance.set.assert_called_with(key, False)
-        else:
-            ret = utils.is_sata30orless('/dev/sda')
-            mock_subprocess_check_output.assert_not_called()
+
+        # Case 1: Key is not in DataBase
+        mock_db_instance.get.return_value = None
+        ret = utils.is_sata30orless('/dev/sda')
+        mock_subprocess_check_output.assert_called()
+        mock_db_instance.set.assert_called_with(key, False)
+        self.assertEqual(ret, False)
+
+        mock_subprocess_check_output.reset_mock()
+        mock_db_instance.reset_mock()
+
+        # Case 2: Key already exists in DataBase
+        mock_db_instance.get.return_value = False
+        ret = utils.is_sata30orless('/dev/sda')
+        mock_subprocess_check_output.assert_not_called()
+        mock_db_instance.set.assert_not_called()
+        self.assertEqual(ret, False)
 
     @patch('subprocess.check_output')
     @patch('charmhelpers.core.unitdata.kv')
@@ -115,18 +125,28 @@ class CephUtilsTestCase(unittest.TestCase):
                          b'SATA 3.0, 6.0 Gb/s (current: 6.0 Gb/s)\n'
                          b'supressed text\n\n')
         mock_subprocess_check_output.return_value = extcmd_output
+
         mock_db_instance = MagicMock()
         mock_db.return_value = mock_db_instance
+
         key = '/dev/sda_is_sata30orless'
+
+        # Case 1: Key is not in DataBase
         mock_db_instance.get.return_value = None
-        if mock_db_instance.get(key) is None:
-            ret = utils.is_sata30orless('/dev/sda')
-            mock_subprocess_check_output.assert_called()
-            self.assertEqual(ret, True)
-            mock_db_instance.set.assert_called_with(key, True)
-        else:
-            ret = utils.is_sata30orless('/dev/sda')
-            mock_subprocess_check_output.assert_not_called()
+        ret = utils.is_sata30orless('/dev/sda')
+        mock_subprocess_check_output.assert_called()
+        mock_db_instance.set.assert_called_with(key, True)
+        self.assertEqual(ret, True)
+
+        mock_subprocess_check_output.reset_mock()
+        mock_db_instance.reset_mock()
+
+        # Case 2: Key already exists in DataBase
+        mock_db_instance.get.return_value = True
+        ret = utils.is_sata30orless('/dev/sda')
+        mock_subprocess_check_output.assert_not_called()
+        mock_db_instance.set.assert_not_called()
+        self.assertEqual(ret, True)
 
     @patch('subprocess.check_output')
     @patch('charmhelpers.core.unitdata.kv')
@@ -136,18 +156,28 @@ class CephUtilsTestCase(unittest.TestCase):
                          b'SATA 2.6, 3.0 Gb/s (current: 3.0 Gb/s)\n'
                          b'supressed text\n\n')
         mock_subprocess_check_output.return_value = extcmd_output
+
         mock_db_instance = MagicMock()
         mock_db.return_value = mock_db_instance
+
         key = '/dev/sda_is_sata30orless'
+
+        # Case 1: Key is not in DataBase
         mock_db_instance.get.return_value = None
-        if mock_db_instance.get(key) is None:
-            ret = utils.is_sata30orless('/dev/sda')
-            mock_subprocess_check_output.assert_called()
-            self.assertEqual(ret, True)
-            mock_db_instance.set.assert_called_with(key, True)
-        else:
-            ret = utils.is_sata30orless('/dev/sda')
-            mock_subprocess_check_output.assert_not_called()
+        ret = utils.is_sata30orless('/dev/sda')
+        mock_subprocess_check_output.assert_called()
+        mock_db_instance.set.assert_called_with(key, True)
+        self.assertEqual(ret, True)
+
+        mock_subprocess_check_output.reset_mock()
+        mock_db_instance.reset_mock()
+
+        # Case 2: Key already exists in DataBase
+        mock_db_instance.get.return_value = True
+        ret = utils.is_sata30orless('/dev/sda')
+        mock_subprocess_check_output.assert_not_called()
+        mock_db_instance.set.assert_not_called()
+        self.assertEqual(ret, True)
 
     @patch.object(utils, "function_get")
     def test_raise_on_missing_arguments(self, mock_function_get):


### PR DESCRIPTION
# Description
Smartctl does not need to run everytime during update-status hook.
Putting the output of smartctl of each device in kv and using it as cache for subsequent runs

Fixes # https://bugs.launchpad.net/charm-ceph-osd/+bug/2040135