### PR TITLE
feat(code): update list-shares action to fetch the access list

### DIFF
--- a/ceph-nfs/src/charm.py
+++ b/ceph-nfs/src/charm.py
@@ -483,7 +483,10 @@ class CephNFSCharm(
         event.set_results({
             "exports": [
                 {
-                    "id": export.export_id, "name": export.name
+                    "id": export.export_id,
+                    "name": export.name,
+                    "read-only-clients": export.clients_by_mode['r'],
+                    "read-write-clients": export.clients_by_mode['rw']
                 } for export in exports
             ]
         })

--- a/ceph-nfs/tests/nfs_ganesha.py
+++ b/ceph-nfs/tests/nfs_ganesha.py
@@ -197,5 +197,7 @@ class NfsGaneshaTest(unittest.TestCase):
         logging.debug("Action results: {}".format(results))
         logging.debug("exports: {}".format(results['exports']))
         exports = yaml.safe_load(results['exports'])
-        self.assertIn('test_ganesha_list_share',
-                      [export['name'] for export in exports])
+        for export in exports:
+            self.assertEqual('test_ganesha_list_share', export['name'])
+            self.assertEqual(export['read-only-clients'], [])
+            self.assertEqual(['0.0.0.0'], export['read-write-clients'])


### PR DESCRIPTION

# Description

Update to list-shares action, to fetch the list of clients granted access to the share. Change utilises existing clients_by_mode attribute in the Export object. After the change list-shares action will show `read-only-clients` and `read-write-clients`. 
Updates include changes to list-share event handler, additional unit test for 'list_shares' function and update to functional test 'test_list_shares'

Before 
`exports: '[{''id'': 1002, ''name'': ''test-share''}]'`

After 
`exports: '[{''id'': 1002, ''name'': ''test-share'', ''read-only-clients'': [], ''read-write-clients'':
  [''0.0.0.0'']}]'`

Fixes # [2077881](https://bugs.launchpad.net/charm-ceph-nfs/+bug/2077881)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Added test_list_shares unit test to unit_tests/test_ganesha.py. 
Modified test_list_shares functional test in tests/nfs_ganesha.py