### PR TITLE
Fixing _run_cmd to handle larger output

### DIFF
--- a/ceph-dashboard/src/ceph_dashboard_commands.py
+++ b/ceph-dashboard/src/ceph_dashboard_commands.py
@@ -24,9 +24,10 @@ def _run_cmd(cmd: List[str]):
 
     `cmd` The command to run
     """
-    return subprocess.check_output(
-        cmd, stderr=subprocess.STDOUT
-    ).decode('UTF-8')
+    proc = subprocess.run(
+        cmd, capture_output=True, check=True, encoding="UTF-8",
+    )
+    return proc.stdout + proc.stderr
 
 
 def exec_option_ceph_cmd(option: CharmCephOption, value: str) -> None:

--- a/ceph-dashboard/unit_tests/test_ceph_dashboard_commands.py
+++ b/ceph-dashboard/unit_tests/test_ceph_dashboard_commands.py
@@ -8,7 +8,26 @@ import subprocess
 import tempfile
 import os
 
-from ceph_dashboard_commands import validate_ssl_keypair
+from ceph_dashboard_commands import validate_ssl_keypair, _run_cmd
+
+from unittest.mock import patch, MagicMock
+
+
+class TestCephDashboardCommand(unittest.TestCase):
+    @patch('ceph_dashboard_commands.subprocess.run')
+    def test_run_cmd(self, mock_run):
+        # Mock the Popen object and its methods
+        process_mock = MagicMock()
+        process_mock.stdout = 'output line 1\noutput line 2\n'
+        process_mock.stderr = ''
+        process_mock.returncode = 0
+        mock_run.return_value = process_mock
+
+        # Execute the function
+        result = _run_cmd(['echo', 'test'])
+
+        # Verify the result
+        self.assertEqual(result, 'output line 1\noutput line 2\n')
 
 
 class TestSSLValidation(unittest.TestCase):


### PR DESCRIPTION
Using run instead of check_output to handle larger output.

Closes-bug: #2095293

test result (zaza)
https://paste.ubuntu.com/p/9DKqFQrxqs/
https://paste.ubuntu.com/p/wZkH2T82KM/