### PR TITLE
Testing: generate crashdumps on cancel event

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -159,7 +159,7 @@ jobs:
           fi
 
       - name: Generate crash dumps
-        if: failure()
+        if: ${{ failure() || cancelled() }}
         run: |
           models=$(juju models | grep zaza | awk '{print $1}' | tr -d '*')
           rm -rf ./crashdumps
@@ -176,7 +176,7 @@ jobs:
         if: failure()
 
       - name: Setup tmate session
-        if: ${{ failure() && runner.debug }}
+        if: ${{ (failure() || cancelled()) && runner.debug }}
         uses: canonical/action-tmate@main
 
       - name: Tear down models


### PR DESCRIPTION
We used to only create crashdumps on test faults. However if a test times out (esp. func tests are prone to timeouts) this doesn't get caught. This PR tries to remedy that. Similarly for setting up tmate