### PR TITLE
ceph-proxy: Remove .coveragerc file

### DIFF
--- a/ceph-proxy/.coveragerc
+++ b/ceph-proxy/.coveragerc
@@ -1,7 +1,0 @@
-[report]
-# Regexes for lines to exclude from consideration
-exclude_lines =
-    if __name__ == .__main__.:
-include=
-    hooks/hooks.py
-    hooks/ceph*.py


### PR DESCRIPTION
The presence of this file was making the `tox -e cover` command to fail, so it was removed. It apparently served no purpose.
