### PR TITLE
ceph-dashboard: centralize SSL config

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: read
     name: Canonical CLA signed
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v2

--- a/ceph-dashboard/src/ceph_dashboard_commands.py
+++ b/ceph-dashboard/src/ceph_dashboard_commands.py
@@ -266,7 +266,7 @@ def set_ssl_material(key_path, cert_path) -> None:
     ceph_utils.mgr_config_set(
         'mgr/dashboard/ssl',
         'true')
-    # Set the ssl artifacte without the hostname which appears to
+    # Set the ssl artifact without the hostname which appears to
     # be required even though they aren't used.
     logging.debug("Setting SSL cert w/o hostname")
     ceph_utils.dashboard_set_ssl_certificate(cert_path)

--- a/ceph-dashboard/tests/tests.yaml
+++ b/ceph-dashboard/tests/tests.yaml
@@ -3,6 +3,8 @@ gate_bundles:
   - noble-caracal
 smoke_bundles:
   - noble-caracal
+dev_bundles:
+  - noble-caracal
 configure:
   - zaza.openstack.charm_tests.vault.setup.auto_initialize_no_validation
   - tests.target.setup.check_dashboard_cert

--- a/ceph-dashboard/unit_tests/test_ceph_dashboard_commands.py
+++ b/ceph-dashboard/unit_tests/test_ceph_dashboard_commands.py
@@ -8,9 +8,28 @@ import subprocess
 import tempfile
 import os
 
-from ceph_dashboard_commands import validate_ssl_keypair, _run_cmd
-
 from unittest.mock import patch, MagicMock
+
+from ceph_dashboard_commands import (
+    validate_ssl_keypair,
+    _run_cmd,
+    ceph_mgr_instances,
+)
+
+
+TEST_MGR_DUMP = """
+{
+    "active_name": "foomgr",
+    "active_addrs": {},
+    "available": true,
+    "standbys": [
+        {
+            "name": "barmgr",
+            "mgr_features": 4540701547738038271,
+            "available_modules": []
+        }]
+}
+"""
 
 
 class TestCephDashboardCommand(unittest.TestCase):
@@ -149,6 +168,13 @@ class TestSSLValidation(unittest.TestCase):
         """Test validation with empty inputs"""
         is_valid, message = validate_ssl_keypair(b"", b"")
         self.assertFalse(is_valid)
+
+    @patch("ceph_dashboard_commands._run_cmd")
+    def test_ceph_mgr_instances(self, run_cmd):
+        """Test retrieving ceph mgr instances"""
+        run_cmd.return_value = TEST_MGR_DUMP
+        mgrs = ceph_mgr_instances()
+        self.assertEqual(mgrs, ["foomgr", "barmgr"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Only configure ssl material on leader unit to prevent races

Fixes https://bugs.launchpad.net/charm-ceph-dashboard/+bug/2033886

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This has been tested in SQA integration tests

## Contributor's Checklist

Please check that you have:

- [x] considered and tested upgrade scenarios from a previous stable version.
- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
