### PR TITLE
ceph-proxy: Fix coverage

### DIFF
--- a/ceph-proxy/.coveragerc
+++ b/ceph-proxy/.coveragerc
@@ -1,7 +1,0 @@
-[report]
-# Regexes for lines to exclude from consideration
-exclude_lines =
-    if __name__ == .__main__.:
-include=
-    hooks/hooks.py
-    hooks/ceph*.py


### PR DESCRIPTION
The .coveragerc file present in the ceph-proxy directory was causing the `tox -e cover` command to fail. Since it served no apparent purpose, the file was removed.

