### PR TITLE
Fixing the issue that nova-compute-ceph-auth-c91ce26f is not created.

### DIFF
--- a/ceph-proxy/hooks/ceph_hooks.py
+++ b/ceph-proxy/hooks/ceph_hooks.py
@@ -291,6 +291,15 @@ def client_relation_changed():
             if not is_leader():
                 log("Not leader - ignoring broker request", level=DEBUG)
             else:
+                # client.nova-compute is created when joined
+                # client.nova-compute-ceph-auth-c91ce26f which is from
+                # nova-compute charm need to be created.
+                # refer to charm-nova-compute
+                # commit#650f3a5d511690ec27648b30f3b24532378a33a1
+                # in changed hook otherwise the key will not be created
+                # get_named_key is creating auth if there is no one.
+                ceph.get_named_key(settings["application-name"])
+
                 rsp = process_requests(settings['broker_req'])
                 unit_id = remote_unit().replace('/', '-')
                 unit_response_key = 'broker-rsp-' + unit_id

--- a/ceph-proxy/unit_tests/test_ceph_hooks.py
+++ b/ceph-proxy/unit_tests/test_ceph_hooks.py
@@ -229,3 +229,48 @@ class TestHooks(test_utils.CharmTestCase):
         hooks.config_changed()
         mock_package_install.assert_called_with()
         mock_emit_cephconf.assert_called_with()
+
+    @mock.patch('ceph_hooks.is_leader')
+    @mock.patch('ceph_hooks.process_requests')
+    @mock.patch('ceph_hooks.ceph')
+    @mock.patch('ceph_hooks.ready')
+    def test_client_relation_changed(self, mock_ready, mock_ceph,
+                                     mock_process_requests, mock_is_leader):
+        # Test client_relation_changed
+        # If not ready or missing request data, does nothing.
+        # If ready, has request data and is leader,
+        # check broker request and set response.
+        # and check get_named_key called correctly.
+        self.remote_unit.return_value = 'client/0'
+        mock_process_requests.return_value = 'test-response'
+
+        mock_ready.return_value = False
+        hooks.client_relation_changed()
+        mock_process_requests.assert_not_called()
+        self.relation_set.assert_not_called()
+
+        mock_ready.return_value = True
+
+        self.relation_get.return_value = {}
+        hooks.client_relation_changed()
+        mock_process_requests.assert_not_called()
+        self.relation_set.assert_not_called()
+
+        self.relation_get.return_value = {
+            'broker_req': 'test-request',
+            'application-name': 'test-app'
+        }
+        mock_is_leader.return_value = False
+        hooks.client_relation_changed()
+        mock_process_requests.assert_not_called()
+        self.relation_set.assert_not_called()
+
+        mock_is_leader.return_value = True
+        hooks.client_relation_changed()
+        mock_ceph.get_named_key.assert_called_with('test-app')
+        mock_process_requests.assert_called_with('test-request')
+        expected_data = {
+            'broker_rsp': 'test-response',
+            'broker-rsp-client-0': 'test-response'
+        }
+        self.relation_set.assert_called_with(relation_settings=expected_data)


### PR DESCRIPTION
ceph-proxy doesn't create nova-compute-ceph-auth-c91ce26f. nova-compute key is legacy and nova-compute-ceph-auth-c91ce26f is new. Since nova-compute-ceph-auth-c91ce26f is reported in changed hook, we need to add get_named_key in changed hook.


(cherry picked from commit 6bec1960cd574312116132c66d12f9d202354b0c)

Fixes #67 
