### PR TITLE
Fixing the issue that nova-compute-ceph-auth-c91ce26f is not created.

### DIFF
--- a/ceph-proxy/hooks/ceph_hooks.py
+++ b/ceph-proxy/hooks/ceph_hooks.py
@@ -248,6 +248,15 @@ def client_relation_changed():
             if not is_leader():
                 log("Not leader - ignoring broker request", level=DEBUG)
             else:
+                # client.nova-compute is created when joined
+                # client.nova-compute-ceph-auth-c91ce26f which is from
+                # nova-compute charm need to be created.
+                # refer to charm-nova-compute
+                # commit#650f3a5d511690ec27648b30f3b24532378a33a1
+                # in changed hook otherwise the key will not be created
+                # get_named_key is creating auth if there is no one.
+                ceph.get_named_key(settings["application-name"])
+
                 rsp = process_requests(settings['broker_req'])
                 unit_id = remote_unit().replace('/', '-')
                 unit_response_key = 'broker-rsp-' + unit_id


### PR DESCRIPTION
ceph-proxy doesn't create nova-compute-ceph-auth-c91ce26f. nova-compute key is legacy and nova-compute-ceph-auth-c91ce26f is new. Since nova-compute-ceph-auth-c91ce26f is reported in changed hook, we need to add get_named_key in changed hook.


(cherry picked from commit 6bec1960cd574312116132c66d12f9d202354b0c)

Fixes #67 
