### PR TITLE
build: pin calver

### DIFF
--- a/ceph-rbd-mirror/src/wheelhouse.txt
+++ b/ceph-rbd-mirror/src/wheelhouse.txt
@@ -2,3 +2,5 @@ git+https://github.com/juju/charm-helpers.git#egg=charmhelpers
 psutil
 poetry-core
 git+https://github.com/openstack/charms.openstack.git#egg=charms.openstack
+# https://github.com/di/calver/pull/21
+calver==2025.3.31


### PR DESCRIPTION
We indirectly (via urllib3 and hatchling) depend on calver, per https://github.com/di/calver/pull/21 newer calver depends on setuptools>=77.0.1 but this conflicts with layer-basic. Pin calver to avoid this

Backport from https://github.com/canonical/ceph-charms/pull/83