### PR TITLE
feat: add git info to charm builds

### DIFF
--- a/ceph-fs/charmcraft.yaml
+++ b/ceph-fs/charmcraft.yaml
@@ -2,6 +2,7 @@ type: charm
 
 parts:
   charm:
+    after: [git-info]
     plugin: reactive
     reactive-charm-build-arguments:
       - --binary-wheels-from-source
@@ -17,6 +18,17 @@ parts:
     build-environment:
       - CHARM_INTERFACES_DIR: $CRAFT_PROJECT_DIR/interfaces/
       - CHARM_LAYERS_DIR: $CRAFT_PROJECT_DIR/layers/
+  git-info:
+    plugin: nil
+    build-packages: [git]
+    override-build: |
+      craftctl default
+      if git -C $CRAFT_PROJECT_DIR rev-parse --git-dir > /dev/null 2>&1; then
+        echo "commit: $(git -C $CRAFT_PROJECT_DIR rev-parse HEAD)" > $CRAFT_PART_INSTALL/git-info.txt
+        echo "branch: $(git -C $CRAFT_PROJECT_DIR symbolic-ref -q --short HEAD || echo DETACHED)" >> $CRAFT_PART_INSTALL/git-info.txt
+        echo "commit_date: $(git -C $CRAFT_PROJECT_DIR show -s --format=%cI HEAD)" >> $CRAFT_PART_INSTALL/git-info.txt
+      fi
+
 
 base: ubuntu@22.04
 build-base: ubuntu@22.04

--- a/ceph-mon/charmcraft.yaml
+++ b/ceph-mon/charmcraft.yaml
@@ -12,11 +12,23 @@ parts:
 
   update-certificates:
     # Ensure that certificates in the base image are up-to-date.
+    after: [git-info]
     plugin: nil
     override-build: |
       apt update
       apt install -y ca-certificates
       update-ca-certificates
+
+  git-info:
+    plugin: nil
+    build-packages: [git]
+    override-build: |
+      craftctl default
+      if git -C $CRAFT_PROJECT_DIR rev-parse --git-dir > /dev/null 2>&1; then
+        echo "commit: $(git -C $CRAFT_PROJECT_DIR rev-parse HEAD)" > $CRAFT_PART_INSTALL/git-info.txt
+        echo "branch: $(git -C $CRAFT_PROJECT_DIR symbolic-ref -q --short HEAD || echo DETACHED)" >> $CRAFT_PART_INSTALL/git-info.txt
+        echo "commit_date: $(git -C $CRAFT_PROJECT_DIR show -s --format=%cI HEAD)" >> $CRAFT_PART_INSTALL/git-info.txt
+      fi
 
 base: ubuntu@22.04
 platforms:

--- a/ceph-nfs/charmcraft.yaml
+++ b/ceph-nfs/charmcraft.yaml
@@ -8,12 +8,25 @@ parts:
       - git
 
   update-certificates:
+    after: [git-info]
     plugin: nil
     # See https://github.com/canonical/charmcraft/issues/658
     override-build: |
       apt update
       apt install -y ca-certificates
       update-ca-certificates
+
+  git-info:
+    plugin: nil
+    build-packages: [git]
+    override-build: |
+      craftctl default
+      if git -C $CRAFT_PROJECT_DIR rev-parse --git-dir > /dev/null 2>&1; then
+        echo "commit: $(git -C $CRAFT_PROJECT_DIR rev-parse HEAD)" > $CRAFT_PART_INSTALL/git-info.txt
+        echo "branch: $(git -C $CRAFT_PROJECT_DIR symbolic-ref -q --short HEAD || echo DETACHED)" >> $CRAFT_PART_INSTALL/git-info.txt
+        echo "commit_date: $(git -C $CRAFT_PROJECT_DIR show -s --format=%cI HEAD)" >> $CRAFT_PART_INSTALL/git-info.txt
+      fi
+
 
 base: ubuntu@22.04
 build-base: ubuntu@22.04

--- a/ceph-osd/charmcraft.yaml
+++ b/ceph-osd/charmcraft.yaml
@@ -2,8 +2,19 @@ type: charm
 
 parts:
   charm:
+    after: [git-info]
     plugin: dump
     source: .
+  git-info:
+    plugin: nil
+    build-packages: [git]
+    override-build: |
+      craftctl default
+      if git -C $CRAFT_PROJECT_DIR rev-parse --git-dir > /dev/null 2>&1; then
+        echo "commit: $(git -C $CRAFT_PROJECT_DIR rev-parse HEAD)" > $CRAFT_PART_INSTALL/git-info.txt
+        echo "branch: $(git -C $CRAFT_PROJECT_DIR symbolic-ref -q --short HEAD || echo DETACHED)" >> $CRAFT_PART_INSTALL/git-info.txt
+        echo "commit_date: $(git -C $CRAFT_PROJECT_DIR show -s --format=%cI HEAD)" >> $CRAFT_PART_INSTALL/git-info.txt
+      fi
 
 base: ubuntu@22.04
 platforms:

--- a/ceph-proxy/charmcraft.yaml
+++ b/ceph-proxy/charmcraft.yaml
@@ -2,6 +2,7 @@ type: charm
 
 parts:
   charm:
+    after: [git-info]
     plugin: dump
     source: .
     prime:
@@ -20,6 +21,17 @@ parts:
       - Makefile
       - metadata.yaml
       - README.md
+
+  git-info:
+    plugin: nil
+    build-packages: [git]
+    override-build: |
+      craftctl default
+      if git -C $CRAFT_PROJECT_DIR rev-parse --git-dir > /dev/null 2>&1; then
+        echo "commit: $(git -C $CRAFT_PROJECT_DIR rev-parse HEAD)" > $CRAFT_PART_INSTALL/git-info.txt
+        echo "branch: $(git -C $CRAFT_PROJECT_DIR symbolic-ref -q --short HEAD || echo DETACHED)" >> $CRAFT_PART_INSTALL/git-info.txt
+        echo "commit_date: $(git -C $CRAFT_PROJECT_DIR show -s --format=%cI HEAD)" >> $CRAFT_PART_INSTALL/git-info.txt
+      fi
 
 base: ubuntu@22.04
 platforms:

--- a/ceph-radosgw/charmcraft.yaml
+++ b/ceph-radosgw/charmcraft.yaml
@@ -2,8 +2,20 @@ type: charm
 
 parts:
   charm:
+    after: [git-info]
     plugin: dump
     source: .
+
+  git-info:
+    plugin: nil
+    build-packages: [git]
+    override-build: |
+      craftctl default
+      if git -C $CRAFT_PROJECT_DIR rev-parse --git-dir > /dev/null 2>&1; then
+        echo "commit: $(git -C $CRAFT_PROJECT_DIR rev-parse HEAD)" > $CRAFT_PART_INSTALL/git-info.txt
+        echo "branch: $(git -C $CRAFT_PROJECT_DIR symbolic-ref -q --short HEAD || echo DETACHED)" >> $CRAFT_PART_INSTALL/git-info.txt
+        echo "commit_date: $(git -C $CRAFT_PROJECT_DIR show -s --format=%cI HEAD)" >> $CRAFT_PART_INSTALL/git-info.txt
+      fi
 
 base: ubuntu@22.04
 platforms:

--- a/ceph-rbd-mirror/charmcraft.yaml
+++ b/ceph-rbd-mirror/charmcraft.yaml
@@ -2,6 +2,7 @@ type: charm
 
 parts:
   charm:
+    after: [git-info]
     source: src/
     plugin: reactive
     build-snaps:
@@ -13,6 +14,17 @@ parts:
     build-environment:
       - CHARM_INTERFACES_DIR: /root/project/interfaces/
       - CHARM_LAYERS_DIR: /root/project/layers/
+
+  git-info:
+    plugin: nil
+    build-packages: [git]
+    override-build: |
+      craftctl default
+      if git -C $CRAFT_PROJECT_DIR rev-parse --git-dir > /dev/null 2>&1; then
+        echo "commit: $(git -C $CRAFT_PROJECT_DIR rev-parse HEAD)" > $CRAFT_PART_INSTALL/git-info.txt
+        echo "branch: $(git -C $CRAFT_PROJECT_DIR symbolic-ref -q --short HEAD || echo DETACHED)" >> $CRAFT_PART_INSTALL/git-info.txt
+        echo "commit_date: $(git -C $CRAFT_PROJECT_DIR show -s --format=%cI HEAD)" >> $CRAFT_PART_INSTALL/git-info.txt
+      fi
 
 base: ubuntu@22.04
 platforms:

--- a/ceph-rbd-mirror/src/wheelhouse.txt
+++ b/ceph-rbd-mirror/src/wheelhouse.txt
@@ -2,3 +2,5 @@ git+https://github.com/juju/charm-helpers.git#egg=charmhelpers
 psutil
 poetry-core
 git+https://github.com/openstack/charms.openstack.git#egg=charms.openstack
+# https://github.com/di/calver/pull/21
+calver==2025.3.31


### PR DESCRIPTION
Add git information to the built charm in the form of a git-info.txt file

This is a backport from https://github.com/canonical/ceph-charms/pull/69 