### PR TITLE
Fix call to 'apt.remove_package'

### DIFF
--- a/ceph-mon/src/charm.py
+++ b/ceph-mon/src/charm.py
@@ -74,7 +74,7 @@ class CephMonCharm(ops_openstack.core.OSBaseCharm):
         self.install_pkgs()
         rm_packages = ceph.determine_packages_to_remove()
         if rm_packages:
-            apt.remove_package(packages=rm_packages, fatal=True)
+            apt.remove_package(package_names=rm_packages)
         try:
             # we defer and explicitly run `ceph-create-keys` from
             # add_keyring_to_ceph() as part of bootstrap process


### PR DESCRIPTION
The function was being used with wrong arguments, probably as a side effect of the rewrite to an op charm. The function's contract can be seen here: https://opendev.org/openstack/charm-ceph-mon/src/branch/master/lib/charms/operator_libs_linux/v0/apt.py#L805