### PR TITLE
feat!: integrate `ceph-fs` with `filesystem-client`

### DIFF
--- a/ceph-fs/.gitignore
+++ b/ceph-fs/.gitignore
@@ -11,3 +11,5 @@ __pycache__
 .project
 .pydevproject
 interfaces/*
+!interfaces/filesystem_info
+!interfaces/cephfs_share

--- a/ceph-fs/interfaces/filesystem_info/interface.yaml
+++ b/ceph-fs/interfaces/filesystem_info/interface.yaml
@@ -1,0 +1,3 @@
+name: filesystem_info
+summary: Filesystem provider interface
+version: 1

--- a/ceph-fs/interfaces/filesystem_info/provides.py
+++ b/ceph-fs/interfaces/filesystem_info/provides.py
@@ -1,0 +1,168 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Library to expose a Ceph filesystem through the `filesystem` integration.
+
+This library is an adaptation of the [`filesystem_info`] charm library, which provides common classes for managing an
+integration between a filesystem server operator and a filesystem client operator. The library only
+exposes the classes related with the provider side of the integration, and only the Ceph-related
+classes.
+
+[`filesystem_info`]: https://github.com/charmed-hpc/filesystem-charms/blob/main/charms/filesystem-client/lib/charms/filesystem_client/v0/filesystem_info.py
+```
+"""
+
+from dataclasses import dataclass
+from urllib.parse import quote, urlencode, urlunsplit
+
+from charms.reactive import when, set_flag, clear_flag
+from charms.reactive.endpoints import Endpoint
+
+from charmhelpers.core import hookenv
+
+__all__ = [
+    "FilesystemInfoError",
+    "FilesystemProvides",
+]
+
+
+class FilesystemInfoError(Exception):
+    """Exception raised when an operation failed."""
+
+
+# Design-wise, this class represents the grammar that relations use to
+# share data between providers and requirers:
+#
+# key = 1*( unreserved )
+# value = 1*( unreserved / ":" / "/" / "?" / "#" / "[" / "]" / "@" / "!" / "$"
+#       / "'" / "(" / ")" / "*" / "+" / "," / ";" )
+# options = key "=" value ["&" options]
+# host-port = host [":" port]
+# hosts = host-port [',' hosts]
+# authority = [userinfo "@"] "(" hosts ")"
+# URI = scheme "://" authority path-absolute ["?" options]
+#
+# Unspecified grammar rules are given by [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#appendix-A).
+#
+# This essentially leaves 5 components that the library can use to share data:
+# - scheme: representing the type of filesystem.
+# - hosts: representing the list of hosts where the filesystem lives. For NFS it should be a single element,
+#   but CephFS and Lustre use more than one endpoint.
+# - user: Any kind of authentication user that the client must specify to mount the filesystem.
+# - path: The internally exported path of each filesystem. Could be optional if a filesystem exports its
+#   whole tree, but at the very least NFS, CephFS and Lustre require an export path.
+# - options: Some filesystems will require additional options for its specific mount command (e.g. Ceph).
+#
+# Putting all together, this allows sharing the required data using simple URI strings:
+# ```
+# <scheme>://<user>@(<host>,*)/<path>/?<options>
+#
+# ceph://fsuser@(192.168.1.1,192.168.1.2,192.168.1.3)/export?fsid=asdf1234&auth=plain:QWERTY1234&filesystem=fs_name
+# ```
+#
+# Note how in the Lustre URI we needed to escape the `@` symbol on the hosts to conform with the URI syntax.
+@dataclass(init=False, frozen=True)
+class _UriData:
+    """Raw data from the endpoint URI of a relation."""
+
+    scheme: str
+    """Scheme used to identify a filesystem.
+
+    This will mostly correspond to the option `fstype` for the `mount` command.
+    """
+
+    hosts: list[str]
+    """List of hosts where the filesystem is deployed on."""
+
+    user: str
+    """User to connect to the filesystem."""
+
+    path: str
+    """Path exported by the filesystem."""
+
+    options: dict[str, str]
+    """Additional options that could be required to mount the filesystem."""
+
+    def __init__(
+        self,
+        scheme: str,
+        hosts: list[str],
+        user: str = "",
+        path: str = "/",
+        options: dict[str, str] = {},
+    ) -> None:
+        if not scheme:
+            raise FilesystemInfoError("scheme cannot be empty")
+        if not hosts:
+            raise FilesystemInfoError("list of hosts cannot be empty")
+        path = path or "/"
+
+        object.__setattr__(self, "scheme", scheme)
+        object.__setattr__(self, "hosts", hosts)
+        object.__setattr__(self, "user", user)
+        object.__setattr__(self, "path", path)
+        object.__setattr__(self, "options", options)
+
+    def __str__(self) -> str:
+        user = quote(self.user)
+        hostname = quote(",".join(self.hosts))
+        path = quote(self.path)
+        netloc = f"{user}@({hostname})" if user else f"({hostname})"
+        query = urlencode(self.options)
+        return urlunsplit((self.scheme, netloc, path, query, None))
+
+
+class FilesystemProvides(Endpoint):
+    """Provider-side interface of filesystem integrations."""
+
+    @when("endpoint.{endpoint_name}.joined")
+    def handle_joined(self):
+        if hookenv.is_leader():
+            set_flag(self.expand_name("{endpoint_name}.available"))
+
+    def manage_flags(self):
+        if not self.is_joined:
+            clear_flag(self.expand_name("{endpoint_name}.available"))
+
+    def set_info(self, fsid: str, name: str, path: str, monitor_hosts: list[str], user: str, key: str) -> None:
+        """Set information to mount a Ceph filesystem.
+
+        Args:
+            - fsid: ID of the Ceph cluster.
+            - name: Name of the exported Ceph filesystem.
+            - path: Exported path of the Ceph filesystem.
+            - monitor_hosts: Address list of the available Ceph MON nodes.
+            - user: Name of the user authorized to access the Ceph filesystem.
+            - key: Cephx key for the authorized user.
+
+        Notes:
+            Only the application leader unit can set the filesystem data.
+        """
+        if hookenv.is_leader():
+            for relation in self.relations:
+                relation.to_publish_app_raw.update(
+                    {
+                        "endpoint": str(_UriData(
+                            scheme="cephfs",
+                            hosts=monitor_hosts,
+                            path=path,
+                            user=user,
+                            options={
+                                "fsid": fsid,
+                                "name": name,
+                                "auth": f"plain:{key}"
+                            }
+                        )),
+                    }
+                )

--- a/ceph-fs/src/build.lock
+++ b/ceph-fs/src/build.lock
@@ -13,8 +13,8 @@
       "item": "layer:basic",
       "url": "https://github.com/juju-solutions/layer-basic.git",
       "vcs": null,
-      "branch": "33526bd6aaa01ffe717a5c66ed62bc4790344ef2",
-      "commit": "33526bd6aaa01ffe717a5c66ed62bc4790344ef2"
+      "branch": "3384ec303104c5f28a19d5779ac4caa1c741cd73",
+      "commit": "3384ec303104c5f28a19d5779ac4caa1c741cd73"
     },
     {
       "type": "layer",
@@ -37,16 +37,16 @@
       "item": "ceph-fs",
       "url": null,
       "vcs": null,
-      "branch": "e6c6f13cde785174cee1a48a8df1c581e394fc3b",
-      "commit": "e6c6f13cde785174cee1a48a8df1c581e394fc3b"
+      "branch": "e673c0429134e02f0de235fb36d5c1b0f9321819",
+      "commit": "e673c0429134e02f0de235fb36d5c1b0f9321819"
     },
     {
       "type": "layer",
       "item": "interface:tls-certificates",
       "url": "https://github.com/juju-solutions/interface-tls-certificates",
       "vcs": null,
-      "branch": "da891c403864482688ec767a964218e5857f0e49",
-      "commit": "da891c403864482688ec767a964218e5857f0e49"
+      "branch": "236e089493c96feac5ea1a8617b1059a4477a04e",
+      "commit": "236e089493c96feac5ea1a8617b1059a4477a04e"
     },
     {
       "type": "layer",
@@ -58,167 +58,27 @@
     },
     {
       "type": "layer",
+      "item": "interface:filesystem_info",
+      "url": null,
+      "vcs": null,
+      "branch": "e673c0429134e02f0de235fb36d5c1b0f9321819",
+      "commit": "e673c0429134e02f0de235fb36d5c1b0f9321819"
+    },
+    {
+      "type": "layer",
       "item": "interface:cephfs_share",
       "url": null,
       "vcs": null,
-      "branch": "e6c6f13cde785174cee1a48a8df1c581e394fc3b",
-      "commit": "e6c6f13cde785174cee1a48a8df1c581e394fc3b"
+      "branch": "e673c0429134e02f0de235fb36d5c1b0f9321819",
+      "commit": "e673c0429134e02f0de235fb36d5c1b0f9321819"
     },
     {
       "type": "python_module",
-      "package": "dnspython3",
-      "vcs": null,
-      "version": "1.12.0"
-    },
-    {
-      "type": "python_module",
-      "package": "netifaces",
-      "vcs": null,
-      "version": "0.11.0"
-    },
-    {
-      "type": "python_module",
-      "package": "packaging",
-      "vcs": null,
-      "version": "24.1"
-    },
-    {
-      "type": "python_module",
-      "package": "setuptools",
-      "vcs": null,
-      "version": "71.1.0"
-    },
-    {
-      "type": "python_module",
-      "package": "pyaml",
-      "vcs": null,
-      "version": "21.10.1"
-    },
-    {
-      "type": "python_module",
-      "package": "flit_scm",
-      "vcs": null,
-      "version": "1.7.0"
-    },
-    {
-      "type": "python_module",
-      "package": "charms.reactive",
-      "url": "git+https://github.com/canonical/charms.reactive.git",
-      "branch": "0dc82abb7ac01f288042ee44b56a9d428c8fc46c",
-      "version": "0dc82abb7ac01f288042ee44b56a9d428c8fc46c",
+      "package": "charms.openstack",
+      "url": "git+https://github.com/openstack/charms.openstack.git",
+      "branch": "562012b05ea7f0828f5c10e2cf09be6218191ce0",
+      "version": "562012b05ea7f0828f5c10e2cf09be6218191ce0",
       "vcs": "git"
-    },
-    {
-      "type": "python_module",
-      "package": "psutil",
-      "vcs": null,
-      "version": "6.0.0"
-    },
-    {
-      "type": "python_module",
-      "package": "pyxattr",
-      "vcs": null,
-      "version": "0.8.1"
-    },
-    {
-      "type": "python_module",
-      "package": "MarkupSafe",
-      "vcs": null,
-      "version": "2.1.5"
-    },
-    {
-      "type": "python_module",
-      "package": "trove_classifiers",
-      "vcs": null,
-      "version": "2024.7.2"
-    },
-    {
-      "type": "python_module",
-      "package": "flit_core",
-      "vcs": null,
-      "version": "3.9.0"
-    },
-    {
-      "type": "python_module",
-      "package": "PyYAML",
-      "vcs": null,
-      "version": "6.0.1"
-    },
-    {
-      "type": "python_module",
-      "package": "charmhelpers",
-      "url": "git+https://github.com/juju/charm-helpers.git",
-      "branch": "1b2d4dc8f8effd79d782241a32a0485af1f01e73",
-      "version": "1b2d4dc8f8effd79d782241a32a0485af1f01e73",
-      "vcs": "git"
-    },
-    {
-      "type": "python_module",
-      "package": "pip",
-      "vcs": null,
-      "version": "22.0.4"
-    },
-    {
-      "type": "python_module",
-      "package": "calver",
-      "vcs": null,
-      "version": "2022.6.26"
-    },
-    {
-      "type": "python_module",
-      "package": "pluggy",
-      "vcs": null,
-      "version": "1.5.0"
-    },
-    {
-      "type": "python_module",
-      "package": "pyudev",
-      "vcs": null,
-      "version": "0.24.3"
-    },
-    {
-      "type": "python_module",
-      "package": "six",
-      "vcs": null,
-      "version": "1.16.0"
-    },
-    {
-      "type": "python_module",
-      "package": "pathspec",
-      "vcs": null,
-      "version": "0.12.1"
-    },
-    {
-      "type": "python_module",
-      "package": "jinja2",
-      "vcs": null,
-      "version": "3.1.4"
-    },
-    {
-      "type": "python_module",
-      "package": "pbr",
-      "vcs": null,
-      "version": "6.0.0"
-    },
-    {
-      "type": "python_module",
-      "package": "charms.ceph",
-      "url": "git+https://github.com/openstack/charms.ceph.git",
-      "branch": "64f3c1b12b14545a76321469478fb456b379832d",
-      "version": "64f3c1b12b14545a76321469478fb456b379832d",
-      "vcs": "git"
-    },
-    {
-      "type": "python_module",
-      "package": "looseversion",
-      "vcs": null,
-      "version": "1.3.0"
-    },
-    {
-      "type": "python_module",
-      "package": "hatchling",
-      "vcs": null,
-      "version": "1.25.0"
     },
     {
       "type": "python_module",
@@ -234,23 +94,103 @@
     },
     {
       "type": "python_module",
-      "package": "charms.openstack",
-      "url": "git+https://github.com/openstack/charms.openstack.git",
-      "branch": "355d65f64cc1dac133d885aa7cfc58b1804a0c30",
-      "version": "355d65f64cc1dac133d885aa7cfc58b1804a0c30",
+      "package": "pyaml",
+      "vcs": null,
+      "version": "21.10.1"
+    },
+    {
+      "type": "python_module",
+      "package": "dnspython",
+      "vcs": null,
+      "version": "2.7.0"
+    },
+    {
+      "type": "python_module",
+      "package": "charms.ceph",
+      "url": "git+https://github.com/openstack/charms.ceph.git",
+      "branch": "1a66fb4a0154b2f9b0e2fdff76d18bb7302194cc",
+      "version": "1a66fb4a0154b2f9b0e2fdff76d18bb7302194cc",
+      "vcs": "git"
+    },
+    {
+      "type": "python_module",
+      "package": "setuptools",
+      "vcs": null,
+      "version": "80.9.0"
+    },
+    {
+      "type": "python_module",
+      "package": "pbr",
+      "vcs": null,
+      "version": "6.1.0"
+    },
+    {
+      "type": "python_module",
+      "package": "flit_scm",
+      "vcs": null,
+      "version": "1.7.0"
+    },
+    {
+      "type": "python_module",
+      "package": "pluggy",
+      "vcs": null,
+      "version": "1.6.0"
+    },
+    {
+      "type": "python_module",
+      "package": "MarkupSafe",
+      "vcs": null,
+      "version": "2.1.5"
+    },
+    {
+      "type": "python_module",
+      "package": "packaging",
+      "vcs": null,
+      "version": "25.0"
+    },
+    {
+      "type": "python_module",
+      "package": "pyudev",
+      "vcs": null,
+      "version": "0.24.3"
+    },
+    {
+      "type": "python_module",
+      "package": "setuptools_scm",
+      "vcs": null,
+      "version": "8.3.1"
+    },
+    {
+      "type": "python_module",
+      "package": "charmhelpers",
+      "url": "git+https://github.com/juju/charm-helpers.git",
+      "branch": "33c08fc064069c30237b47f1998ac9996351301a",
+      "version": "33c08fc064069c30237b47f1998ac9996351301a",
       "vcs": "git"
     },
     {
       "type": "python_module",
       "package": "wheel",
       "vcs": null,
-      "version": "0.43.0"
+      "version": "0.45.1"
     },
     {
       "type": "python_module",
-      "package": "dnspython",
+      "package": "jinja2",
       "vcs": null,
-      "version": "2.6.1"
+      "version": "3.1.6"
+    },
+    {
+      "type": "python_module",
+      "package": "pathspec",
+      "vcs": null,
+      "version": "0.12.1"
+    },
+    {
+      "type": "python_module",
+      "package": "trove_classifiers",
+      "vcs": null,
+      "version": "2025.5.9.12"
     },
     {
       "type": "python_module",
@@ -260,9 +200,77 @@
     },
     {
       "type": "python_module",
-      "package": "setuptools_scm",
+      "package": "flit_core",
       "vcs": null,
-      "version": "8.1.0"
+      "version": "3.12.0"
+    },
+    {
+      "type": "python_module",
+      "package": "dnspython3",
+      "vcs": null,
+      "version": "1.12.0"
+    },
+    {
+      "type": "python_module",
+      "package": "hatchling",
+      "vcs": null,
+      "version": "1.27.0"
+    },
+    {
+      "type": "python_module",
+      "package": "pyyaml",
+      "vcs": null,
+      "version": "6.0.2"
+    },
+    {
+      "type": "python_module",
+      "package": "charms.reactive",
+      "url": "git+https://github.com/canonical/charms.reactive.git",
+      "branch": "f7debc39e623a3a73673ba1f7e4cb5bc7ae9ecd9",
+      "version": "f7debc39e623a3a73673ba1f7e4cb5bc7ae9ecd9",
+      "vcs": "git"
+    },
+    {
+      "type": "python_module",
+      "package": "netifaces",
+      "vcs": null,
+      "version": "0.11.0"
+    },
+    {
+      "type": "python_module",
+      "package": "looseversion",
+      "vcs": null,
+      "version": "1.3.0"
+    },
+    {
+      "type": "python_module",
+      "package": "six",
+      "vcs": null,
+      "version": "1.17.0"
+    },
+    {
+      "type": "python_module",
+      "package": "calver",
+      "vcs": null,
+      "version": "2025.4.17"
+    },
+    {
+      "type": "python_module",
+      "package": "pyxattr",
+      "vcs": null,
+      "version": "0.8.1"
+    },
+    {
+      "type": "python_module",
+      "package": "pip",
+      "vcs": null,
+      "version": "22.0.4"
+    },
+    {
+      "type": "python_module",
+      "package": "psutil",
+      "vcs": null,
+      "version": "7.0.0"
     }
   ]
 }

--- a/ceph-fs/src/layer.yaml
+++ b/ceph-fs/src/layer.yaml
@@ -1,4 +1,4 @@
-includes: ['layer:ceph', 'interface:ceph-mds', 'interface:cephfs_share']
+includes: ['layer:ceph', 'interface:ceph-mds', 'interface:filesystem_info', 'interface:cephfs_share']
 options:
   basic:
     use_venv: True

--- a/ceph-fs/src/metadata.yaml
+++ b/ceph-fs/src/metadata.yaml
@@ -19,6 +19,8 @@ requires:
 provides:
   cephfs-share:
     interface: cephfs_share
+  filesystem:
+    interface: filesystem_info
 
 extra-bindings:
   public:


### PR DESCRIPTION
# Description

This PR replaces the interface `cephfs-share` on `ceph-fs` (which is pretty much deprecated) with `filesystem_info`, making it possible to integrate a Ceph cluster + `ceph-fs` with the `filesystem-client` to automatically mount a CephFS in a principal charm.

This technically is a breaking change, but the old interface is not really used in the wild; searching for `cephfs-share` on Github results in usages from only Charmed HPC and Canonical repositories; so I guessed it would be fine to replace the interface. Let me know if it would be better to avoid the breaking change by preserving the old interface.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Modified the unit tests to reflect the change in the interface. Also manually tested deploying Microceph with [this patch applied](https://github.com/canonical/charm-microceph/pull/179), `ceph-fs` and `filesystem-client`, which seems to work correctly.

## Contributor's Checklist

Please check that you have:

- [x] considered and tested upgrade scenarios from a previous stable version.
- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
