### PR TITLE
backport: Exclude erasure coded pools by default

### DIFF
--- a/ceph-rbd-mirror/charmcraft.yaml
+++ b/ceph-rbd-mirror/charmcraft.yaml
@@ -2,7 +2,8 @@ type: charm
 
 parts:
   charm:
-    source: src/
+    source: .
+    source-subdir: src/
     plugin: reactive
     build-snaps:
       - charm
@@ -11,6 +12,7 @@ parts:
       - git
       - python3-dev
     build-environment:
+      - PIP_CONSTRAINT: $CRAFT_PART_BUILD_WORK/constraints.txt
       - CHARM_INTERFACES_DIR: /root/project/interfaces/
       - CHARM_LAYERS_DIR: /root/project/layers/
 

--- a/ceph-rbd-mirror/src/build.lock
+++ b/ceph-rbd-mirror/src/build.lock
@@ -86,12 +86,6 @@
     },
     {
       "type": "python_module",
-      "package": "setuptools_scm",
-      "vcs": null,
-      "version": "6.4.2"
-    },
-    {
-      "type": "python_module",
       "package": "MarkupSafe",
       "vcs": null,
       "version": "2.1.5"

--- a/ceph-rbd-mirror/src/constraints.txt
+++ b/ceph-rbd-mirror/src/constraints.txt
@@ -1,0 +1,2 @@
+# src/contraints.txt
+setuptools_scm < 8.2.0; python_version <= "3.8"

--- a/ceph-rbd-mirror/unit_tests/test_lib_charm_openstack_ceph_rbd_mirror.py
+++ b/ceph-rbd-mirror/unit_tests/test_lib_charm_openstack_ceph_rbd_mirror.py
@@ -248,3 +248,31 @@ class TestCephRBDMirrorCharm(Helper):
         self.assertEqual('pool', rq0)
         rq1 = crmc.pool_mirroring_mode('pool-rq1', broker_requests)
         self.assertEqual('image', rq1)
+
+    def test_eligible_pools(self):
+        pools = {
+            'rbd-replicated': {
+                'applications': {'rbd': {}},
+                'parameters': {'erasure_code_profile': ''},
+            },
+            'rbd-ec-metadata': {
+                'applications': {'rbd': {}},
+                'parameters': {'erasure_code_profile': ''},
+            },
+            'rbd-ec-data': {
+                'applications': {'rbd'},
+                'parameters': {'erasure_code_profile': 'test_profile'},
+            },
+            'non-rbd-pool': {
+                'applications': {'rgw': {}},
+                'parameters': {},
+            },
+        }
+
+        crmc = ceph_rbd_mirror.CephRBDMirrorCharm()
+        eligible = crmc.eligible_pools(pools)
+        self.assertIsNotNone(eligible)
+        self.assertEqual(eligible, {
+            name: attrs for name, attrs in pools.items()
+            if name in {'rbd-replicated', 'rbd-ec-metadata'}
+        })


### PR DESCRIPTION
If the pool is erasure coded, then skip that pool as it cannot be used for rbd mirroring. The metadata pool should be used instead.

Closes-Bug: #1898504
