### PR TITLE
build: target quincy to jammy

### DIFF
--- a/ceph-dashboard/charmcraft.yaml
+++ b/ceph-dashboard/charmcraft.yaml
@@ -19,7 +19,7 @@ parts:
       apt install -y ca-certificates
       update-ca-certificates
 
-base: ubuntu@20.04
+base: ubuntu@22.04
 platforms:
   amd64:
     build-on: amd64

--- a/ceph-fs/charmcraft.yaml
+++ b/ceph-fs/charmcraft.yaml
@@ -18,8 +18,7 @@ parts:
       - CHARM_INTERFACES_DIR: $CRAFT_PROJECT_DIR/interfaces/
       - CHARM_LAYERS_DIR: $CRAFT_PROJECT_DIR/layers/
 
-base: ubuntu@20.04
-build-base: ubuntu@20.04
+base: ubuntu@22.04
 platforms:
   amd64:
     build-on: amd64

--- a/ceph-iscsi/charmcraft.yaml
+++ b/ceph-iscsi/charmcraft.yaml
@@ -20,7 +20,7 @@ parts:
       apt install -y ca-certificates
       update-ca-certificates
 
-base: ubuntu@20.04
+base: ubuntu@22.04
 platforms:
   amd64:
     build-on: amd64

--- a/ceph-mon/charmcraft.yaml
+++ b/ceph-mon/charmcraft.yaml
@@ -18,7 +18,7 @@ parts:
       apt install -y ca-certificates
       update-ca-certificates
 
-base: ubuntu@20.04
+base: ubuntu@22.04
 platforms:
   amd64:
     build-on: amd64

--- a/ceph-nfs/charmcraft.yaml
+++ b/ceph-nfs/charmcraft.yaml
@@ -15,8 +15,7 @@ parts:
       apt install -y ca-certificates
       update-ca-certificates
 
-base: ubuntu@20.04
-build-base: ubuntu@20.04
+base: ubuntu@22.04
 platforms:
   amd64:
     build-on: amd64

--- a/ceph-osd/charmcraft.yaml
+++ b/ceph-osd/charmcraft.yaml
@@ -5,7 +5,7 @@ parts:
     plugin: dump
     source: .
 
-base: ubuntu@20.04
+base: ubuntu@22.04
 platforms:
   amd64:
     build-on: amd64

--- a/ceph-proxy/charmcraft.yaml
+++ b/ceph-proxy/charmcraft.yaml
@@ -21,7 +21,7 @@ parts:
       - metadata.yaml
       - README.md
 
-base: ubuntu@20.04
+base: ubuntu@22.04
 platforms:
   amd64:
     build-on: amd64

--- a/ceph-radosgw/charmcraft.yaml
+++ b/ceph-radosgw/charmcraft.yaml
@@ -5,7 +5,7 @@ parts:
     plugin: dump
     source: .
 
-base: ubuntu@20.04
+base: ubuntu@22.04
 platforms:
   amd64:
     build-on: amd64

--- a/ceph-rbd-mirror/charmcraft.yaml
+++ b/ceph-rbd-mirror/charmcraft.yaml
@@ -16,7 +16,7 @@ parts:
       - CHARM_INTERFACES_DIR: /root/project/interfaces/
       - CHARM_LAYERS_DIR: /root/project/layers/
 
-base: ubuntu@20.04
+base: ubuntu@22.04
 platforms:
   amd64:
     build-on: amd64


### PR DESCRIPTION
We were lacking support for quincy on jammy in the migrated ceph charms. Focal (20.04) is EOL by now, we need to target jammy (22.04) for quincy though.


