### PR TITLE
Fix cephx key rotation race condition with Nova

### DIFF
--- a/ceph-mon/unit_tests/test_ceph_client_key_handling.py
+++ b/ceph-mon/unit_tests/test_ceph_client_key_handling.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from unittest.mock import MagicMock
+from test_utils import CharmTestCase
+
+
+class TestCephClientKeyHandling(CharmTestCase):
+    """Test cephx key handling, i.e., fix for LP#2125295."""
+
+    def setUp(self):
+        super(TestCephClientKeyHandling, self).setUp()
+
+    def test_reuse_existing_key_when_no_application_name(self):
+        """Test that existing key is reused when application-name not set.
+
+        When a client relation data doesn't include 'application-name',
+        reuse the existing key if one exists, rather than generating a
+        new key. This avoids a race condition where new units are
+        temporarily configured with the wrong key.
+        """
+
+        relation = MagicMock()
+        this_unit = MagicMock()
+        client_unit = MagicMock()
+
+        # Mock relational data
+        relation.data = {
+            this_unit: {'key': 'cephx-existing-key'},
+            client_unit: {}  # Client has no 'application-name' set yet
+        }
+
+        # Added logic from _handle_client_relation
+        ceph_key = relation.data[this_unit].get('key', None)
+        if 'application-name' not in relation.data[client_unit] and ceph_key:
+            key_to_use = ceph_key
+        else:
+            key_to_use = None
+
+        self.assertEqual(
+            key_to_use, 'cephx-existing-key',
+            "Use existing key when application-name not in client data")


### PR DESCRIPTION
# Description

When new nova-compute units are added to Ceph-backed clouds, cephx keys are temporarily reverted back to the wrong (old) key value. This happens due to a race condition between the client hooks of nova-compute and ceph-mon. Details can be found in LP#2125295.

This patch ensures that ceph-mon checks whether the new unit has finished its configurations already and if not, keeps using the same key value.

Closes-Bug: #2125295

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

I have set up a lab an tested the fix, I can no longer see the issue after the changes are applied.

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

## Contributor's Checklist

Please check that you have:

- [ ] considered and tested upgrade scenarios from a previous stable version.
- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
