### PR TITLE
fix: setuptools/wheel pin for building

### DIFF
--- a/ceph-nfs/charmcraft.yaml
+++ b/ceph-nfs/charmcraft.yaml
@@ -6,6 +6,9 @@ parts:
       - update-certificates
     build-packages:
       - git
+    charm-python-packages:
+      - "setuptools<70"
+      - "wheel<0.44"
 
   update-certificates:
     plugin: nil


### PR DESCRIPTION
# Description

Pin setuptools and wheels to compatible versions

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

