### PR TITLE
fix(backport): ceph-proxy user key retrieval

### DIFF
--- a/ceph-fs/test-requirements.txt
+++ b/ceph-fs/test-requirements.txt
@@ -18,6 +18,12 @@ stestr>=2.2.0
 # https://github.com/mtreinish/stestr/issues/145
 cliff<3.0.0
 
+# setuptools>=82 removed pkg_resources which is used by cliff<3.0.0.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
+
 # Dependencies of stestr. Newer versions use keywords that didn't exist in
 # python 3.5 yet (e.g. "ModuleNotFoundError")
 importlib-metadata<3.0.0; python_version < '3.6'

--- a/ceph-iscsi/tox.ini
+++ b/ceph-iscsi/tox.ini
@@ -91,7 +91,6 @@ deps = -r{toxinidir}/requirements.txt
 [testenv:pep8]
 basepython = python3
 deps = flake8
-       charm-tools
 commands = flake8 {posargs} unit_tests tests src
 
 [testenv:cover]

--- a/ceph-nfs/test-requirements.txt
+++ b/ceph-nfs/test-requirements.txt
@@ -1,11 +1,17 @@
 # This file is managed centrally.  If you find the need to modify this as a
 # one-off, please don't.  Intead, consult #openstack-charms and ask about
 # requirements management in charms via bot-control.  Thank you.
-charm-tools>=2.4.4
 coverage>=3.6
 mock>=1.2
 flake8>=2.2.4
 stestr>=2.2.0
+
+# setuptools>=82 removed pkg_resources which is used by cliff<3.0.0.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
+
 requests>=2.18.4
 psutil
 # oslo.i18n dropped py35 support

--- a/ceph-nfs/tox.ini
+++ b/ceph-nfs/tox.ini
@@ -89,7 +89,6 @@ deps = -r{toxinidir}/requirements.txt
 [testenv:pep8]
 basepython = python3
 deps = flake8
-       charm-tools
 commands = flake8 {posargs} unit_tests tests src
 
 [testenv:cover]

--- a/ceph-osd/test-requirements.txt
+++ b/ceph-osd/test-requirements.txt
@@ -17,6 +17,12 @@ stestr>=2.2.0
 # https://github.com/mtreinish/stestr/issues/145
 cliff<3.0.0
 
+# setuptools>=82 removed pkg_resources which is used by cliff<3.0.0.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
+
 coverage>=4.5.2
 pyudev              # for ceph-* charm unit tests (need to fix the ceph-* charm unit tests/mocking)
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza

--- a/ceph-proxy/hooks/ceph.py
+++ b/ceph-proxy/hooks/ceph.py
@@ -392,14 +392,32 @@ def get_upgrade_key():
 
 def _config_user_key(name):
     user_keys_list = config('user-keys')
-    if user_keys_list:
-        for ukpair in user_keys_list.split(' '):
-            uk = ukpair.split(':')
-            if len(uk) == 2:
-                user_type, k = uk
-                t, u = user_type.split('.')
-                if u == name:
-                    return k
+    if not user_keys_list:
+        return None
+
+    for ukpair in user_keys_list.split():
+        if ':' not in ukpair:
+            log('Ignoring malformed user-keys entry', level=WARNING)
+            continue
+
+        user_type, key = ukpair.split(':', 1)
+        if not user_type or not key:
+            log('Ignoring malformed user-keys entry', level=WARNING)
+            continue
+
+        if '.' in user_type:
+            _, user = user_type.split('.', 1)
+        else:
+            user = user_type
+
+        if not user:
+            log('Ignoring malformed user-keys entry', level=WARNING)
+            continue
+
+        if user == name:
+            return key
+
+    return None
 
 
 def get_named_entity_key(name, caps=None, pool_list=None,
@@ -478,6 +496,9 @@ def get_named_key(name, caps=None, pool_list=None):
     :param pool_list: The list of pools to give access to
     :returns: Returns a cephx key
     """
+    config_user_key = _config_user_key(name)
+    if config_user_key:
+        return config_user_key
     return get_named_entity_key(name, caps, pool_list, entity='client')
 
 

--- a/ceph-proxy/test-requirements.txt
+++ b/ceph-proxy/test-requirements.txt
@@ -18,6 +18,12 @@ stestr>=2.2.0
 # https://github.com/mtreinish/stestr/issues/145
 cliff<3.0.0
 
+# setuptools>=82 removed pkg_resources which is used by cliff<3.0.0.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
+
 # Dependencies of stestr. Newer versions use keywords that didn't exist in
 # python 3.5 yet (e.g. "ModuleNotFoundError")
 importlib-metadata<3.0.0; python_version < '3.6'

--- a/ceph-proxy/tox.ini
+++ b/ceph-proxy/tox.ini
@@ -89,7 +89,6 @@ deps = -r{toxinidir}/requirements.txt
 [testenv:pep8]
 basepython = python3
 deps = flake8
-       charm-tools
 commands = flake8 {posargs} unit_tests tests actions files
 
 [testenv:cover]

--- a/ceph-proxy/unit_tests/test_ceph.py
+++ b/ceph-proxy/unit_tests/test_ceph.py
@@ -42,12 +42,88 @@ class CephTestCase(unittest.TestCase):
         self.assertEqual(user_key, named_key)
 
     @mock.patch('ceph.config')
+    def test_config_user_key_supports_entity_with_multiple_dots(
+            self,
+            mock_config):
+        user_name = 'radosgw.gateway'
+        user_key = 'AQBljmtb65mrHhAAGy9VRkfsatWVLb9EpoWDfw=='
+
+        mock_config.side_effect = self.populated_config_side_effect
+        named_key = ceph._config_user_key(user_name)
+        self.assertEqual(user_key, named_key)
+
+    @mock.patch('ceph.config')
+    def test_config_user_key_supports_unqualified_username(self, mock_config):
+        user_name = 'glance'
+        user_key = 'AQCnjmtbuEACMxAA7joUmgLIGI4/3LKkPzUy8g=='
+
+        mock_config.side_effect = lambda key: {
+            'user-keys': 'glance:{} client.cinder-ceph:other'.format(user_key),
+            'admin-user': 'client.myadmin',
+        }[key]
+        named_key = ceph._config_user_key(user_name)
+        self.assertEqual(user_key, named_key)
+
+    @mock.patch('ceph.log')
+    @mock.patch('ceph.config')
+    def test_config_user_key_ignores_malformed_entries(
+            self,
+            mock_config,
+            mock_log):
+        user_name = 'glance'
+        user_key = 'AQCnjmtbuEACMxAA7joUmgLIGI4/3LKkPzUy8g=='
+
+        mock_config.side_effect = lambda key: {
+            'user-keys': (
+                'malformed-entry '
+                'client.radosgw.gateway '
+                'client.glance:{}'
+            ).format(user_key),
+            'admin-user': 'client.myadmin',
+        }[key]
+        named_key = ceph._config_user_key(user_name)
+        self.assertEqual(user_key, named_key)
+        self.assertTrue(mock_log.called)
+
+    @mock.patch('ceph.config')
     def test_config_empty_user_key(self, mock_config):
         user_name = 'cinder-ceph'
 
         mock_config.side_effect = self.empty_config_side_effect
         named_key = ceph._config_user_key(user_name)
         self.assertEqual(named_key, None)
+
+    @mock.patch('ceph.get_named_entity_key')
+    @mock.patch('ceph.config')
+    def test_get_named_key_falls_back_when_user_keys_are_malformed(
+            self, mock_config, mock_get_named_entity_key):
+        user_name = 'cinder-ceph'
+        expected_key = 'generated-key'
+
+        mock_config.side_effect = lambda key: {
+            'user-keys': 'broken-entry client.glance',
+            'admin-user': 'client.myadmin',
+        }[key]
+        mock_get_named_entity_key.return_value = expected_key
+
+        named_key = ceph.get_named_key(user_name)
+
+        self.assertEqual(expected_key, named_key)
+        mock_get_named_entity_key.assert_called_once_with(
+            user_name, None, None, entity='client')
+
+    @mock.patch('ceph.get_named_entity_key')
+    @mock.patch('ceph.config')
+    def test_get_named_key_prefers_configured_user_key(
+            self, mock_config, mock_get_named_entity_key):
+        user_name = 'glance'
+        expected_key = 'AQCnjmtbuEACMxAA7joUmgLIGI4/3LKkPzUy8g=='
+
+        mock_config.side_effect = self.populated_config_side_effect
+        named_key = ceph.get_named_key(user_name)
+
+        self.assertEqual(expected_key, named_key)
+        mock_get_named_entity_key.assert_not_called()
 
     @mock.patch.object(ceph, 'ceph_user')
     @mock.patch('subprocess.check_output')
@@ -69,7 +145,6 @@ class CephTestCase(unittest.TestCase):
         mock_config.side_effect = self.empty_config_side_effect
         mock_check_output.side_effect = check_output_side_effect
         named_key = ceph.get_named_key(user_name)
-        print(named_key)
 
         self.assertEqual(expected_key, named_key)
 

--- a/ceph-radosgw/test-requirements.txt
+++ b/ceph-radosgw/test-requirements.txt
@@ -17,6 +17,12 @@ stestr>=2.2.0
 # https://github.com/mtreinish/stestr/issues/145
 cliff<3.0.0
 
+# setuptools>=82 removed pkg_resources which is used by various packages.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
+
 coverage>=4.5.2
 pyudev              # for ceph-* charm unit tests (need to fix the ceph-* charm unit tests/mocking)
 git+https://github.com/openstack-charmers/zaza.git#egg=zaza


### PR DESCRIPTION
This reinstates the user-keys functionality for ceph-proxy that has been lost at commit https://github.com/canonical/ceph-charms/commit/8046865c8b545ad47b84ac4667df1eaf084956c7

Fixes: https://bugs.launchpad.net/charm-ceph-proxy/+bug/2142865
Backport of #148 to squid-jammy