### PR TITLE
(stable/quincy.2 backport) sync: Update charms_ceph.utils to osd, proxy, radosgw

### DIFF
--- a/ceph-dashboard/src/charm.py
+++ b/ceph-dashboard/src/charm.py
@@ -148,6 +148,10 @@ class CephDashboardCharm(ops_openstack.core.OSBaseCharm):
             self.on["certificates"].relation_departed,
             self._certificates_relation_departed,
         )
+        self.framework.observe(
+            self.on["certificates"].relation_broken,
+            self._certificates_relation_broken,
+        )
 
         # Charm Custom Events
         self.framework.observe(self.on.disable_ssl, self._clean_ssl_conf)
@@ -556,6 +560,20 @@ class CephDashboardCharm(ops_openstack.core.OSBaseCharm):
             # Possible handover to charm-config SSL.
             if self._is_charm_ssl_from_config():
                 self.on.enable_ssl_from_config.emit()
+
+    def _certificates_relation_broken(self, _event) -> None:
+        """Handle certificates relation fully removed.
+
+        Clear cached certificate data from the ca_client stored state
+        so that _is_charm_ssl_from_relation() returns False. Then
+        force a status re-evaluation to clear stale conflict messages.
+        """
+        self.ca_client._stored.server = None
+        self.ca_client._stored.certificate = None
+        self.ca_client._stored.key = None
+        self.ca_client._stored.ca_certificate = None
+        self.ca_client._stored.root_ca_chain = None
+        self.update_status()
 
     def _configure_tls(self, key, cert, ca_cert, ca_cert_path) -> None:
         """Configure TLS using provided credentials"""

--- a/ceph-dashboard/test-requirements.txt
+++ b/ceph-dashboard/test-requirements.txt
@@ -2,6 +2,10 @@
 # one-off, please don't.  Intead, consult #openstack-charms and ask about
 # requirements management in charms via bot-control.  Thank you.
 setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
+
 coverage>=3.6
 flake8>=2.2.4,<=2.4.1
 pyflakes==2.1.1

--- a/ceph-dashboard/tests/target.py
+++ b/ceph-dashboard/tests/target.py
@@ -20,6 +20,7 @@ import logging
 import collections
 from base64 import b64encode
 import requests
+import tempfile
 import tenacity
 import trustme
 
@@ -103,29 +104,17 @@ def check_dashboard_cert(model_name=None):
     zaza.model.block_until_all_units_idle(model_name=model_name)
 
 
-def set_grafana_url(model_name=None):
-    """Set the url for the grafana api.
-
-    :param model_name: Name of model to query.
-    :type model_name: str
-    """
-    try:
-        unit = zaza.model.get_units('grafana')[0]
-    except KeyError:
-        return
-    zaza.model.set_application_config(
-        'ceph-dashboard',
-        {
-            'grafana-api-url': "https://{}:3000".format(
-                zaza.model.get_unit_public_address(unit))
-        })
-
-
 class CephDashboardTest(test_utils.BaseCharmTest):
     """Class for `ceph-dashboard` tests."""
 
     REMOTE_CERT_FILE = ('/usr/local/share/ca-certificates/'
                         'vault_ca_cert_dashboard.crt')
+
+    @classmethod
+    def get_mgr_key(_, key_name):
+        return zaza.model.run_on_leader(
+            'ceph-mon',
+            'ceph config-key get mgr/dashboard/%s' % key_name)['Stdout']
 
     @classmethod
     def setUpClass(cls):
@@ -135,7 +124,20 @@ class CephDashboardTest(test_utils.BaseCharmTest):
         cls.local_ca_cert = openstack_utils.get_remote_ca_cert_file(
             cls.application_name)
 
-    def _run_request_get(self, url, verify, allow_redirects):
+        cert_file = tempfile.NamedTemporaryFile(mode='w+')
+        key_file = tempfile.NamedTemporaryFile(mode='w+')
+
+        cert_file.write(cls.get_mgr_key('crt'))
+        key_file.write(cls.get_mgr_key('key'))
+
+        cert_file.flush()
+        key_file.flush()
+
+        cls.cert_file = cert_file
+        cls.key_file = key_file
+        cls.verify = cert_file.seek(0) or key_file.seek(0)
+
+    def _run_request_get(self, url, verify, allow_redirects, cert=None):
         """Run a GET request against `url` with tenacity retries.
 
         :param url: url to access
@@ -149,18 +151,23 @@ class CephDashboardTest(test_utils.BaseCharmTest):
         :returns: Request response
         :rtype: requests.models.Response
         """
+
+        if cert is None:
+            cert = (self.cert_file.name, self.key_file.name)
+
         return requests.get(
             url,
-            verify=verify,
+            verify=self.verify and verify,
             allow_redirects=allow_redirects,
-            timeout=120)
+            timeout=120,
+            cert=cert)
 
     @tenacity.retry(wait=tenacity.wait_exponential(multiplier=1,
                                                    min=5, max=10),
                     retry=tenacity.retry_if_exception_type(
                         requests.exceptions.ConnectionError),
                     reraise=True)
-    def _run_request_post(self, url, verify, data, headers):
+    def _run_request_post(self, url, verify, data, headers, cert=None):
         """Run a POST request against `url` with tenacity retries.
 
         :param url: url to access
@@ -176,12 +183,17 @@ class CephDashboardTest(test_utils.BaseCharmTest):
         :returns: Request response
         :rtype: requests.models.Response
         """
+
+        if cert is None:
+            cert = (self.cert_file.name, self.key_file.name)
+
         return requests.post(
             url,
             data=data,
             headers=headers,
-            verify=verify,
-            timeout=120)
+            verify=self.verify and verify,
+            timeout=120,
+            cert=cert)
 
     @tenacity.retry(wait=tenacity.wait_fixed(2), reraise=True,
                     stop=tenacity.stop_after_attempt(90))
@@ -283,8 +295,6 @@ class CephDashboardTest(test_utils.BaseCharmTest):
             dashboard_keys.append('PROMETHEUS_API_HOST')
         ceph_keys.extend(
             ['config/mgr/mgr/dashboard/{}'.format(k) for k in dashboard_keys])
-        if 'ceph-iscsi' in applications:
-            ceph_keys.append('mgr/dashboard/_iscsi_config')
         for key in ceph_keys:
             logging.info("Checking key {} exists".format(key))
             check_out = zaza.model.run_on_leader(
@@ -340,12 +350,12 @@ class CephDashboardTest(test_utils.BaseCharmTest):
             return False
 
     def _get_wait_for_dashboard_assert_state(
-            self, state, message_prefix) -> dict:
+            self, state, message_regex) -> dict:
         """Generate a assert state for ceph-dashboard charm blocked state."""
         assert_state = {
             'ceph-dashboard': {
                 "workload-status": state,
-                "workload-status-message-prefix": message_prefix
+                "workload-status-message-regex": message_regex
             },
             'mysql': {
                 "workload-status": "active",
@@ -355,7 +365,31 @@ class CephDashboardTest(test_utils.BaseCharmTest):
 
         return assert_state
 
-    def verify_ssl_config(self, ca_file):
+    @staticmethod
+    def unit_addr(unit, format_ipv6=True):
+        addr = zaza.model.get_unit_public_address(unit)
+        return network_utils.format_addr(addr) if format_ipv6 else addr
+
+    @staticmethod
+    def dashboard_addr(unit, format_ipv6=True):
+        """
+        The dashboard address may not be the same as the unit's public
+        address, so we get it manually here.
+        """
+        addr = zaza.model.run_on_unit(
+            unit.entity_id,
+            "ss -Htnpl 'sport :8443' | awk '{print $4}'")['Stdout']
+
+        try:
+            addr = addr.strip().replace(':8443', '')
+            ret = network_utils.format_addr(addr)
+            if addr == '0.0.0.0' or addr == '::':
+                return CephDashboardTest.unit_addr(unit, format_ipv6)
+            return ret if format_ipv6 else addr
+        except Exception:
+            return CephDashboardTest.unit_addr(unit, format_ipv6)
+
+    def verify_ssl_config(self, ca_file, cert=None):
         """Check if request validates the configured SSL cert."""
         units = zaza.model.get_units('ceph-mon')
         for attempt in tenacity.Retrying(
@@ -365,13 +399,12 @@ class CephDashboardTest(test_utils.BaseCharmTest):
             with attempt:
                 rcs = collections.defaultdict(list)
                 for unit in units:
-                    ipaddr = network_utils.format_addr(
-                        zaza.model.get_unit_public_address(unit)
-                    )
+                    ipaddr = self.dashboard_addr(unit)
                     req = self._run_request_get(
                         'https://{}:8443'.format(ipaddr),
                         verify=ca_file,
-                        allow_redirects=False)
+                        allow_redirects=False,
+                        cert=cert)
                     rcs[req.status_code].append(ipaddr)
                 self.assertEqual(len(rcs[requests.codes.ok]), 1)
                 self.assertEqual(
@@ -384,7 +417,7 @@ class CephDashboardTest(test_utils.BaseCharmTest):
         # Since Ceph-Dashboard is a subordinate application,
         # we use the principle application to get public addresses.
         for unit in zaza.model.get_units('ceph-mon'):
-            addr = zaza.model.get_unit_public_address(unit)
+            addr = self.dashboard_addr(unit, False)
             if addr:
                 yield addr
 
@@ -412,7 +445,7 @@ class CephDashboardTest(test_utils.BaseCharmTest):
 
         # Check application status message.
         assert_state = self._get_wait_for_dashboard_assert_state(
-            "blocked", "Conflict: Active SSL from 'certificates' relation"
+            "blocked", "SSL.*source"
         )
         zaza.model.wait_for_application_states(
             states=assert_state, timeout=500
@@ -433,8 +466,10 @@ class CephDashboardTest(test_utils.BaseCharmTest):
         )
 
         # Verify Certificates.
-        with local_ca.cert_pem.tempfile() as ca_temp_file:
-            self.verify_ssl_config(ca_temp_file)
+        with (local_ca.cert_pem.tempfile() as ca_temp_file,
+              local_ca.private_key_pem.tempfile() as key_temp_file):
+            self.verify_ssl_config(local_ca,
+                                   (ca_temp_file, key_temp_file))
 
         # Re-add certificates relation
         zaza.model.add_relation(
@@ -444,7 +479,7 @@ class CephDashboardTest(test_utils.BaseCharmTest):
 
         # Check blocked status message
         assert_state = self._get_wait_for_dashboard_assert_state(
-            "blocked", "Conflict: Active SSL from Charm config"
+            "blocked", "SSL.*source"
         )
 
         zaza.model.wait_for_application_states(

--- a/ceph-fs/src/test-requirements.txt
+++ b/ceph-fs/src/test-requirements.txt
@@ -1,7 +1,5 @@
-# This file is managed centrally by release-tools and should not be modified
-# within individual charm repos.  See the 'global' dir contents for available
-# choices of *requirements.txt files for OpenStack Charms:
-#     https://github.com/openstack-charmers/release-tools
+# This file was originally managed centrally by release-tools but has been
+# locally modified after moving to monorepo and is no longer in sync with release-tools.
 
 # NOTE: newer versions of cryptography require a Rust compiler to build,
 # see
@@ -17,6 +15,12 @@ stestr>=2.2.0
 # Dependency of stestr. Workaround for
 # https://github.com/mtreinish/stestr/issues/145
 cliff<3.0.0
+
+# setuptools>=82 removed pkg_resources which is used by cliff<3.0.0.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
 
 # Dependencies of stestr. Newer versions use keywords that didn't exist in
 # python 3.5 yet (e.g. "ModuleNotFoundError")

--- a/ceph-fs/src/wheelhouse.txt
+++ b/ceph-fs/src/wheelhouse.txt
@@ -1,3 +1,5 @@
+# setuptools>=82 removed pkg_resources which is used by charms.layer.basic
+setuptools<82
 netifaces
 dnspython3
 ceph_api

--- a/ceph-fs/test-requirements.txt
+++ b/ceph-fs/test-requirements.txt
@@ -1,7 +1,5 @@
-# This file is managed centrally by release-tools and should not be modified
-# within individual charm repos.  See the 'global' dir contents for available
-# choices of *requirements.txt files for OpenStack Charms:
-#     https://github.com/openstack-charmers/release-tools
+# This file was originally managed centrally by release-tools but has been
+# locally modified after moving to monorepo and is no longer in sync with release-tools.
 
 # NOTE: newer versions of cryptography require a Rust compiler to build,
 # see
@@ -17,6 +15,12 @@ stestr>=2.2.0
 # Dependency of stestr. Workaround for
 # https://github.com/mtreinish/stestr/issues/145
 cliff<3.0.0
+
+# setuptools>=82 removed pkg_resources which is used by cliff<3.0.0.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
 
 # Dependencies of stestr. Newer versions use keywords that didn't exist in
 # python 3.5 yet (e.g. "ModuleNotFoundError")

--- a/ceph-iscsi/test-requirements.txt
+++ b/ceph-iscsi/test-requirements.txt
@@ -1,12 +1,5 @@
-# This file is managed centrally by release-tools and should not be modified
-# within individual charm repos.  See the 'global' dir contents for available
-# choices of *requirements.txt files for OpenStack Charms:
-#     https://github.com/openstack-charmers/release-tools
-#
-# TODO: Distill the func test requirements from the lint/unit test
-#       requirements.  They are intertwined.  Also, Zaza itself should specify
-#       all of its own requirements and if it doesn't, fix it there.
-#
+# This file was originally managed centrally by release-tools but has been
+# locally modified after moving to monorepo and is no longer in sync with release-tools.
 
 # NOTE: newer versions of cryptography require a Rust compiler to build,
 # see
@@ -22,6 +15,12 @@ stestr>=2.2.0
 # Dependency of stestr. Workaround for
 # https://github.com/mtreinish/stestr/issues/145
 cliff<3.0.0
+
+# setuptools>=82 removed pkg_resources which is used by cliff<3.0.0.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
 
 # Dependencies of stestr. Newer versions use keywords that didn't exist in
 # python 3.5 yet (e.g. "ModuleNotFoundError")

--- a/ceph-iscsi/tests/bundles/jammy-antelope.yaml
+++ b/ceph-iscsi/tests/bundles/jammy-antelope.yaml
@@ -34,7 +34,7 @@ applications:
     charm: ch:ceph-osd
     num_units: 3
     storage:
-      osd-devices: 'loop,10G'
+      osd-devices: 'loop,10G,2'
     options:
       osd-devices: '/dev/test-non-existent'
     to:

--- a/ceph-iscsi/tox.ini
+++ b/ceph-iscsi/tox.ini
@@ -91,7 +91,6 @@ deps = -r{toxinidir}/requirements.txt
 [testenv:pep8]
 basepython = python3
 deps = flake8
-       charm-tools
 commands = flake8 {posargs} unit_tests tests src
 
 [testenv:cover]

--- a/ceph-mon/test-requirements.txt
+++ b/ceph-mon/test-requirements.txt
@@ -1,12 +1,5 @@
-# This file is managed centrally by release-tools and should not be modified
-# within individual charm repos.  See the 'global' dir contents for available
-# choices of *requirements.txt files for OpenStack Charms:
-#     https://github.com/openstack-charmers/release-tools
-#
-# TODO: Distill the func test requirements from the lint/unit test
-#       requirements.  They are intertwined.  Also, Zaza itself should specify
-#       all of its own requirements and if it doesn't, fix it there.
-#
+# This file was originally managed centrally by release-tools but has been
+# locally modified after moving to monorepo and is no longer in sync with release-tools.
 
 # NOTE: newer versions of cryptography require a Rust compiler to build,
 # see
@@ -22,6 +15,12 @@ stestr>=2.2.0
 # Dependency of stestr. Workaround for
 # https://github.com/mtreinish/stestr/issues/145
 cliff<3.0.0
+
+# setuptools>=82 removed pkg_resources which is used by cliff<3.0.0.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
 
 # Dependencies of stestr. Newer versions use keywords that didn't exist in
 # python 3.5 yet (e.g. "ModuleNotFoundError")

--- a/ceph-mon/tox.ini
+++ b/ceph-mon/tox.ini
@@ -91,7 +91,6 @@ deps = -r{toxinidir}/requirements.txt
 [testenv:pep8]
 basepython = python3
 deps = flake8
-       charm-tools
 commands = flake8 {posargs} unit_tests tests actions files src
 
 [testenv:cover]

--- a/ceph-nfs/test-requirements.txt
+++ b/ceph-nfs/test-requirements.txt
@@ -1,12 +1,17 @@
-# This file is managed centrally.  If you find the need to modify this as a
-# one-off, please don't.  Intead, consult #openstack-charms and ask about
-# requirements management in charms via bot-control.  Thank you.
+# This file was originally managed centrally but has been locally modified
+# after moving to monorepo and is no longer in sync with the central management system.
 git+https://github.com/openstack/charm-ops-openstack
-charm-tools>=2.4.4
 coverage>=3.6
 mock>=1.2
 flake8>=2.2.4
 stestr>=2.2.0
+
+# setuptools>=82 removed pkg_resources which is used by cliff<3.0.0.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
+
 requests>=2.18.4
 psutil
 # oslo.i18n dropped py35 support

--- a/ceph-nfs/tox.ini
+++ b/ceph-nfs/tox.ini
@@ -91,7 +91,6 @@ deps = -r{toxinidir}/requirements.txt
 [testenv:pep8]
 basepython = python3
 deps = flake8
-       charm-tools
 commands = flake8 {posargs} unit_tests tests src
 
 [testenv:cover]

--- a/ceph-osd/lib/charms_ceph/utils.py
+++ b/ceph-osd/lib/charms_ceph/utils.py
@@ -2920,7 +2920,8 @@ def update_owner(path, recurse_dirs=True):
         secs=elapsed_time.total_seconds(), path=path), DEBUG)
 
 
-def get_osd_state(osd_num, osd_goal_state=None):
+def get_osd_state(osd_num, osd_goal_state=None, timeout=600,
+                  retry_interval=10):
     """Get OSD state or loop until OSD state matches OSD goal state.
 
     If osd_goal_state is None, just return the current OSD state.
@@ -2930,10 +2931,23 @@ def get_osd_state(osd_num, osd_goal_state=None):
     :param osd_num: the OSD id to get state for
     :param osd_goal_state: (Optional) string indicating state to wait for
                            Defaults to None
+    :param timeout: Maximum time in seconds to wait (default: 600)
+    :param retry_interval: Time in seconds between retries (default: 10)
     :returns: Returns a str, the OSD state.
     :rtype: str
     """
+    start_time = time.time()
+
     while True:
+        elapsed_time = time.time() - start_time
+
+        if elapsed_time > timeout:
+            log("Timeout waiting for OSD {} to reach state {}. "
+                "Elapsed time: {:.1f}s".format(
+                    osd_num, osd_goal_state or "any", elapsed_time),
+                level=WARNING)
+            return
+
         asok = "/var/run/ceph/ceph-osd.{}.asok".format(osd_num)
         cmd = [
             'ceph',
@@ -2946,7 +2960,9 @@ def get_osd_state(osd_num, osd_goal_state=None):
                                     .check_output(cmd)
                                     .decode('UTF-8')))
         except (subprocess.CalledProcessError, ValueError) as e:
-            log("{}".format(e), level=DEBUG)
+            log("Failed to get OSD {} state: {} (elapsed: {:.1f}s)".format(
+                osd_num, e, elapsed_time), level=ERROR)
+            time.sleep(retry_interval)
             continue
         osd_state = result['state']
         log("OSD {} state: {}, goal state: {}".format(
@@ -2955,7 +2971,7 @@ def get_osd_state(osd_num, osd_goal_state=None):
             return osd_state
         if osd_state == osd_goal_state:
             return osd_state
-        time.sleep(3)
+        time.sleep(retry_interval)
 
 
 def get_all_osd_states(osd_goal_states=None):

--- a/ceph-osd/test-requirements.txt
+++ b/ceph-osd/test-requirements.txt
@@ -1,21 +1,16 @@
-# This file is managed centrally by release-tools and should not be modified
-# within individual charm repos.  See the 'global' dir contents for available
-# choices of *requirements.txt files for OpenStack Charms:
-#     https://github.com/openstack-charmers/release-tools
-#
-# TODO: Distill the func test requirements from the lint/unit test
-#       requirements.  They are intertwined.  Also, Zaza itself should specify
-#       all of its own requirements and if it doesn't, fix it there.
-#
+# This file was originally managed centrally by release-tools but has been
+# locally modified after moving to monorepo and is no longer in sync with release-tools.
 pyparsing<3.0.0  # aodhclient is pinned in zaza and needs pyparsing < 3.0.0, but cffi also needs it, so pin here.
 
 requests>=2.18.4
 
 stestr>=2.2.0
 
-# Dependency of stestr. Workaround for
-# https://github.com/mtreinish/stestr/issues/145
-cliff<3.0.0
+# setuptools>=82 removed pkg_resources which is used by various packages.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
 
 coverage>=4.5.2
 pyudev              # for ceph-* charm unit tests (need to fix the ceph-* charm unit tests/mocking)

--- a/ceph-osd/tox.ini
+++ b/ceph-osd/tox.ini
@@ -70,7 +70,8 @@ deps = -r{toxinidir}/requirements.txt
 [testenv:pep8]
 basepython = python3
 deps = flake8
-       charm-tools
+allowlist_externals = pip
+commands_pre = pip install git+https://github.com/juju/charm-tools.git
 commands = flake8 {posargs} hooks unit_tests tests actions lib files
            charm-proof
 

--- a/ceph-proxy/lib/charms_ceph/utils.py
+++ b/ceph-proxy/lib/charms_ceph/utils.py
@@ -2926,7 +2926,8 @@ def update_owner(path, recurse_dirs=True):
         secs=elapsed_time.total_seconds(), path=path), DEBUG)
 
 
-def get_osd_state(osd_num, osd_goal_state=None):
+def get_osd_state(osd_num, osd_goal_state=None, timeout=600,
+                  retry_interval=10):
     """Get OSD state or loop until OSD state matches OSD goal state.
 
     If osd_goal_state is None, just return the current OSD state.
@@ -2936,10 +2937,23 @@ def get_osd_state(osd_num, osd_goal_state=None):
     :param osd_num: the OSD id to get state for
     :param osd_goal_state: (Optional) string indicating state to wait for
                            Defaults to None
+    :param timeout: Maximum time in seconds to wait (default: 600)
+    :param retry_interval: Time in seconds between retries (default: 10)
     :returns: Returns a str, the OSD state.
     :rtype: str
     """
+    start_time = time.time()
+
     while True:
+        elapsed_time = time.time() - start_time
+
+        if elapsed_time > timeout:
+            log("Timeout waiting for OSD {} to reach state {}. "
+                "Elapsed time: {:.1f}s".format(
+                    osd_num, osd_goal_state or "any", elapsed_time),
+                level=WARNING)
+            return
+
         asok = "/var/run/ceph/ceph-osd.{}.asok".format(osd_num)
         cmd = [
             'ceph',
@@ -2952,7 +2966,9 @@ def get_osd_state(osd_num, osd_goal_state=None):
                                     .check_output(cmd)
                                     .decode('UTF-8')))
         except (subprocess.CalledProcessError, ValueError) as e:
-            log("{}".format(e), level=DEBUG)
+            log("Failed to get OSD {} state: {} (elapsed: {:.1f}s)".format(
+                osd_num, e, elapsed_time), level=ERROR)
+            time.sleep(retry_interval)
             continue
         osd_state = result['state']
         log("OSD {} state: {}, goal state: {}".format(
@@ -2961,7 +2977,7 @@ def get_osd_state(osd_num, osd_goal_state=None):
             return osd_state
         if osd_state == osd_goal_state:
             return osd_state
-        time.sleep(3)
+        time.sleep(retry_interval)
 
 
 def get_all_osd_states(osd_goal_states=None):

--- a/ceph-proxy/test-requirements.txt
+++ b/ceph-proxy/test-requirements.txt
@@ -1,7 +1,5 @@
-# This file is managed centrally by release-tools and should not be modified
-# within individual charm repos.  See the 'global' dir contents for available
-# choices of *requirements.txt files for OpenStack Charms:
-#     https://github.com/openstack-charmers/release-tools
+# This file was originally managed centrally by release-tools but has been
+# locally modified after moving to monorepo and is no longer in sync with release-tools.
 #
 # TODO: Distill the func test requirements from the lint/unit test
 #       requirements.  They are intertwined.  Also, Zaza itself should specify
@@ -14,6 +12,24 @@ stestr>=2.2.0
 # Dependency of stestr. Workaround for
 # https://github.com/mtreinish/stestr/issues/145
 cliff<3.0.0
+
+# setuptools>=82 removed pkg_resources which is used by cliff<3.0.0.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
+
+# Dependencies of stestr. Newer versions use keywords that didn't exist in
+# python 3.5 yet (e.g. "ModuleNotFoundError")
+importlib-metadata<3.0.0; python_version < '3.6'
+importlib-resources<3.0.0; python_version < '3.6'
+
+# Some Zuul nodes sometimes pull newer versions of these dependencies which
+# dropped support for python 3.5:
+osprofiler<2.7.0;python_version<'3.6'
+stevedore<1.31.0;python_version<'3.6'
+debtcollector<1.22.0;python_version<'3.6'
+oslo.utils<=3.41.0;python_version<'3.6'
 
 coverage>=4.5.2
 pyudev              # for ceph-* charm unit tests (need to fix the ceph-* charm unit tests/mocking)

--- a/ceph-proxy/tox.ini
+++ b/ceph-proxy/tox.ini
@@ -91,7 +91,6 @@ deps = -r{toxinidir}/requirements.txt
 [testenv:pep8]
 basepython = python3
 deps = flake8
-       charm-tools
 commands = flake8 {posargs} unit_tests tests actions files
 
 [testenv:cover]

--- a/ceph-radosgw/lib/charms_ceph/utils.py
+++ b/ceph-radosgw/lib/charms_ceph/utils.py
@@ -2901,7 +2901,8 @@ def update_owner(path, recurse_dirs=True):
         secs=elapsed_time.total_seconds(), path=path), DEBUG)
 
 
-def get_osd_state(osd_num, osd_goal_state=None):
+def get_osd_state(osd_num, osd_goal_state=None, timeout=600,
+                  retry_interval=10):
     """Get OSD state or loop until OSD state matches OSD goal state.
 
     If osd_goal_state is None, just return the current OSD state.
@@ -2911,10 +2912,23 @@ def get_osd_state(osd_num, osd_goal_state=None):
     :param osd_num: the OSD id to get state for
     :param osd_goal_state: (Optional) string indicating state to wait for
                            Defaults to None
+    :param timeout: Maximum time in seconds to wait (default: 600)
+    :param retry_interval: Time in seconds between retries (default: 10)
     :returns: Returns a str, the OSD state.
     :rtype: str
     """
+    start_time = time.time()
+
     while True:
+        elapsed_time = time.time() - start_time
+
+        if elapsed_time > timeout:
+            log("Timeout waiting for OSD {} to reach state {}. "
+                "Elapsed time: {:.1f}s".format(
+                    osd_num, osd_goal_state or "any", elapsed_time),
+                level=WARNING)
+            return
+
         asok = "/var/run/ceph/ceph-osd.{}.asok".format(osd_num)
         cmd = [
             'ceph',
@@ -2927,7 +2941,9 @@ def get_osd_state(osd_num, osd_goal_state=None):
                                     .check_output(cmd)
                                     .decode('UTF-8')))
         except (subprocess.CalledProcessError, ValueError) as e:
-            log("{}".format(e), level=DEBUG)
+            log("Failed to get OSD {} state: {} (elapsed: {:.1f}s)".format(
+                osd_num, e, elapsed_time), level=ERROR)
+            time.sleep(retry_interval)
             continue
         osd_state = result['state']
         log("OSD {} state: {}, goal state: {}".format(
@@ -2936,7 +2952,7 @@ def get_osd_state(osd_num, osd_goal_state=None):
             return osd_state
         if osd_state == osd_goal_state:
             return osd_state
-        time.sleep(3)
+        time.sleep(retry_interval)
 
 
 def get_all_osd_states(osd_goal_states=None):

--- a/ceph-radosgw/test-requirements.txt
+++ b/ceph-radosgw/test-requirements.txt
@@ -1,21 +1,16 @@
-# This file is managed centrally by release-tools and should not be modified
-# within individual charm repos.  See the 'global' dir contents for available
-# choices of *requirements.txt files for OpenStack Charms:
-#     https://github.com/openstack-charmers/release-tools
-#
-# TODO: Distill the func test requirements from the lint/unit test
-#       requirements.  They are intertwined.  Also, Zaza itself should specify
-#       all of its own requirements and if it doesn't, fix it there.
-#
+# This file was originally managed centrally by release-tools but has been
+# locally modified after moving to monorepo and is no longer in sync with release-tools.
 pyparsing<3.0.0  # aodhclient is pinned in zaza and needs pyparsing < 3.0.0, but cffi also needs it, so pin here.
 
 requests>=2.18.4
 
 stestr>=2.2.0
 
-# Dependency of stestr. Workaround for
-# https://github.com/mtreinish/stestr/issues/145
-cliff<3.0.0
+# setuptools>=82 removed pkg_resources which is used by various packages.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
 
 coverage>=4.5.2
 pyudev              # for ceph-* charm unit tests (need to fix the ceph-* charm unit tests/mocking)

--- a/ceph-radosgw/tox.ini
+++ b/ceph-radosgw/tox.ini
@@ -71,7 +71,8 @@ basepython = python3
 deps =
     -c {env:TEST_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openstack-charmers/zaza-openstack-tests/master/constraints/constraints-2024.1.txt}
     flake8
-    charm-tools
+allowlist_externals = pip
+commands_pre = pip install git+https://github.com/juju/charm-tools.git
 commands = flake8 {posargs} hooks unit_tests tests actions lib files
            charm-proof
 

--- a/ceph-rbd-mirror/src/test-requirements.txt
+++ b/ceph-rbd-mirror/src/test-requirements.txt
@@ -1,7 +1,5 @@
-# This file is managed centrally by release-tools and should not be modified
-# within individual charm repos.  See the 'global' dir contents for available
-# choices of *requirements.txt files for OpenStack Charms:
-#     https://github.com/openstack-charmers/release-tools
+# This file was originally managed centrally by release-tools but has been
+# locally modified after moving to monorepo and is no longer in sync with release-tools.
 
 # NOTE: newer versions of cryptography require a Rust compiler to build,
 # see
@@ -17,6 +15,12 @@ stestr>=2.2.0
 # Dependency of stestr. Workaround for
 # https://github.com/mtreinish/stestr/issues/145
 cliff<3.0.0
+
+# setuptools>=82 removed pkg_resources which is used by cliff<3.0.0.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
 
 # Dependencies of stestr. Newer versions use keywords that didn't exist in
 # python 3.5 yet (e.g. "ModuleNotFoundError")

--- a/ceph-rbd-mirror/src/wheelhouse.txt
+++ b/ceph-rbd-mirror/src/wheelhouse.txt
@@ -1,3 +1,5 @@
+# setuptools>=82 removed pkg_resources which is used by charms.layer.basic
+setuptools<82
 git+https://github.com/juju/charm-helpers.git#egg=charmhelpers
 psutil
 git+https://github.com/openstack/charms.openstack.git#egg=charms.openstack

--- a/ceph-rbd-mirror/test-requirements.txt
+++ b/ceph-rbd-mirror/test-requirements.txt
@@ -1,13 +1,16 @@
-# This file is managed centrally by release-tools and should not be modified
-# within individual charm repos.  See the 'global' dir contents for available
-# choices of *requirements.txt files for OpenStack Charms:
-#     https://github.com/openstack-charmers/release-tools
-#
+# This file was originally managed centrally by release-tools but has been
+# locally modified after moving to monorepo and is no longer in sync with release-tools.
 stestr>=2.2.0
 
 # Dependency of stestr. Workaround for
 # https://github.com/mtreinish/stestr/issues/145
 cliff<3.0.0
+
+# setuptools>=82 removed pkg_resources which is used by cliff<3.0.0.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
 
 requests>=2.18.4
 charms.reactive

--- a/ceph-rbd-mirror/tox.ini
+++ b/ceph-rbd-mirror/tox.ini
@@ -83,7 +83,6 @@ commands = stestr run --slowest {posargs}
 [testenv:pep8]
 basepython = python3
 deps = flake8
-       charm-tools
 commands = flake8 {posargs} src unit_tests
 
 [testenv:cover]


### PR DESCRIPTION
Sync get_osd_state timeout changes from charms.ceph to:
- ceph-osd/lib/charms_ceph/utils.py
- ceph-proxy/lib/charms_ceph/utils.py
- ceph-radosgw/lib/charms_ceph/utils.py

