### PR TITLE
fix: don't hardcode admin

### DIFF
--- a/ceph-proxy/lib/charms_ceph/broker.py
+++ b/ceph-proxy/lib/charms_ceph/broker.py
@@ -120,12 +120,13 @@ def get_broker_service():
     The charm config stores ``admin-user`` as a ceph entity name (e.g.
     ``client.admin`` or ``client.anbox``), while the ceph/rados CLI ``--id``
     argument expects only the id portion (e.g. ``admin`` or ``anbox``).
+
+    Strip only the literal ``client.`` prefix when present. Any other value is
+    treated as an already-qualified id and returned unchanged.
     """
     admin_user = (config('admin-user') or 'client.admin').strip()
     if admin_user.startswith('client.'):
-        admin_user = admin_user.split('client.', 1)[1]
-    elif '.' in admin_user:
-        admin_user = admin_user.split('.', 1)[1]
+        admin_user = admin_user[len('client.'):]
 
     return admin_user or 'admin'
 

--- a/ceph-proxy/lib/charms_ceph/broker.py
+++ b/ceph-proxy/lib/charms_ceph/broker.py
@@ -26,6 +26,7 @@ from charms_ceph.utils import (
 from charms_ceph.crush_utils import Crushmap
 
 from charmhelpers.core.hookenv import (
+    config,
     log,
     DEBUG,
     INFO,
@@ -111,6 +112,22 @@ def decode_req_encode_rsp(f):
         return json.dumps(f(json.loads(req)))
 
     return decode_inner
+
+
+def get_broker_service():
+    """Return ceph client id used for broker operations.
+
+    The charm config stores ``admin-user`` as a ceph entity name (e.g.
+    ``client.admin`` or ``client.anbox``), while the ceph/rados CLI ``--id``
+    argument expects only the id portion (e.g. ``admin`` or ``anbox``).
+    """
+    admin_user = (config('admin-user') or 'client.admin').strip()
+    if admin_user.startswith('client.'):
+        admin_user = admin_user.split('client.', 1)[1]
+    elif '.' in admin_user:
+        admin_user = admin_user.split('.', 1)[1]
+
+    return admin_user or 'admin'
 
 
 @decode_req_encode_rsp
@@ -250,15 +267,16 @@ def handle_set_key_permissions(request, service):
 
 
 def update_service_permissions(service, service_obj=None, namespace=None):
-    """Update the key permissions for the named client in Ceph"""
+    """Update the key permissions for the named client in Ceph."""
     if not service_obj:
         service_obj = get_service_groups(service=service, namespace=namespace)
     permissions = pool_permission_list_for_service(service_obj)
-    call = ['ceph', 'auth', 'caps', 'client.{}'.format(service)] + permissions
+    call = ['ceph', '--id', get_broker_service(), 'auth', 'caps',
+            'client.{}'.format(service)] + permissions
     try:
         check_call(call)
     except CalledProcessError as e:
-        log("Error updating key capabilities: {}".format(e))
+        log("Error updating key capabilities: {}".format(e), level=ERROR)
 
 
 def add_pool_to_group(pool, group, namespace=None):
@@ -316,8 +334,10 @@ def get_service_groups(service, namespace=None):
         }
     }
     """
-    service_json = monitor_key_get(service='admin',
-                                   key="cephx.services.{}".format(service))
+    service_json = monitor_key_get(
+        service=get_broker_service(),
+        key="cephx.services.{}".format(service),
+    )
     try:
         service = json.loads(service_json)
     except (TypeError, ValueError):
@@ -364,7 +384,10 @@ def get_group(group_name):
     }
     """
     group_key = get_group_key(group_name=group_name)
-    group_json = monitor_key_get(service='admin', key=group_key)
+    group_json = monitor_key_get(
+        service=get_broker_service(),
+        key=group_key,
+    )
     try:
         group = json.loads(group_json)
     except (TypeError, ValueError):
@@ -380,17 +403,21 @@ def get_group(group_name):
 def save_service(service_name, service):
     """Persist a service in the monitor cluster"""
     service['groups'] = {}
-    return monitor_key_set(service='admin',
-                           key="cephx.services.{}".format(service_name),
-                           value=json.dumps(service, sort_keys=True))
+    return monitor_key_set(
+        service=get_broker_service(),
+        key="cephx.services.{}".format(service_name),
+        value=json.dumps(service, sort_keys=True),
+    )
 
 
 def save_group(group, group_name):
     """Persist a group in the monitor cluster"""
     group_key = get_group_key(group_name=group_name)
-    return monitor_key_set(service='admin',
-                           key=group_key,
-                           value=json.dumps(group, sort_keys=True))
+    return monitor_key_set(
+        service=get_broker_service(),
+        key=group_key,
+        value=json.dumps(group, sort_keys=True),
+    )
 
 
 def get_group_key(group_name):
@@ -912,9 +939,9 @@ def process_requests_v1(reqs):
     for req in reqs:
         op = req.get('op')
         log("Processing op='{}'".format(op), level=DEBUG)
-        # Use admin client since we do not have other client key locations
-        # setup to use them for these operations.
-        svc = 'admin'
+        # Use the configured admin user (via --id form) for broker
+        # operations.
+        svc = get_broker_service()
         if op == "create-pool":
             pool_type = req.get('pool-type')  # "replicated" | "erasure"
 

--- a/ceph-proxy/unit_tests/__init__.py
+++ b/ceph-proxy/unit_tests/__init__.py
@@ -6,6 +6,7 @@ _path = os.path.dirname(os.path.realpath(__file__))
 _actions = os.path.abspath(os.path.join(_path, '../actions'))
 _hooks = os.path.abspath(os.path.join(_path, '../hooks'))
 _charmhelpers = os.path.abspath(os.path.join(_path, '../charmhelpers'))
+_lib = os.path.abspath(os.path.join(_path, '../lib'))
 _unit_tests = os.path.abspath(os.path.join(_path, '../unit_tests'))
 
 
@@ -17,4 +18,5 @@ def _add_path(path):
 _add_path(_actions)
 _add_path(_hooks)
 _add_path(_charmhelpers)
+_add_path(_lib)
 _add_path(_unit_tests)

--- a/ceph-proxy/unit_tests/test_ceph_broker.py
+++ b/ceph-proxy/unit_tests/test_ceph_broker.py
@@ -1,0 +1,126 @@
+from unittest import mock
+import unittest
+import sys
+
+# python-apt is not installed as part of test-requirements but is imported by
+# some charmhelpers modules so create a fake import.
+mock_apt = mock.MagicMock()
+sys.modules['apt'] = mock_apt
+mock_apt.apt_pkg = mock.MagicMock()
+
+mock_apt_pkg = mock.MagicMock()
+sys.modules['apt_pkg'] = mock_apt_pkg
+mock_apt_pkg.upstream_version = mock.MagicMock()
+mock_apt_pkg.upstream_version.return_value = '10.1.2-0ubuntu1'
+
+import charms_ceph.broker as broker
+
+
+class CephBrokerTest(unittest.TestCase):
+
+    @mock.patch('charms_ceph.broker.config')
+    def test_get_broker_service_strips_client_prefix(self, mock_config):
+        mock_config.return_value = 'client.anbox'
+        self.assertEqual('anbox', broker.get_broker_service())
+
+    @mock.patch('charms_ceph.broker.config')
+    def test_get_broker_service_defaults_to_admin(self, mock_config):
+        mock_config.return_value = ''
+        self.assertEqual('admin', broker.get_broker_service())
+
+    @mock.patch('charms_ceph.broker.handle_replicated_pool')
+    @mock.patch('charms_ceph.broker.config')
+    def test_process_requests_v1_uses_configured_admin_service(
+            self,
+            mock_config,
+            mock_handle_replicated_pool):
+        mock_config.return_value = 'client.anbox'
+        req = {'op': 'create-pool', 'name': 'anbox-cloud-lxd', 'replicas': 3}
+
+        broker.process_requests_v1([req])
+
+        mock_handle_replicated_pool.assert_called_once_with(
+            request=req, service='anbox')
+
+    @mock.patch('charms_ceph.broker.monitor_key_get')
+    @mock.patch('charms_ceph.broker.config')
+    def test_get_group_uses_configured_admin_service(
+            self,
+            mock_config,
+            mock_monitor_key_get):
+        mock_config.return_value = 'client.anbox'
+        mock_monitor_key_get.return_value = '{}'
+
+        broker.get_group('test-group')
+
+        mock_monitor_key_get.assert_called_once_with(
+            service='anbox',
+            key='cephx.groups.test-group',
+        )
+
+    @mock.patch('charms_ceph.broker.config')
+    @mock.patch('charms_ceph.broker.check_call')
+    def test_update_service_permissions_uses_configured_admin_service(
+            self, mock_check, mock_config):
+        service_obj = {
+            'group_names': {'rwx': ['images']},
+            'groups': {'images': {'pools': ['anbox-cloud-lxd']}},
+        }
+        mock_config.return_value = 'client.anbox'
+
+        broker.update_service_permissions(
+            service='lxd',
+            service_obj=service_obj,
+        )
+
+        mock_check.assert_called_once_with([
+            'ceph',
+            '--id', 'anbox',
+            'auth', 'caps',
+            'client.lxd',
+            'mon',
+            'allow r, allow command "osd blacklist", '
+            'allow command "osd blocklist"',
+            'osd',
+            'allow rwx pool=anbox-cloud-lxd',
+        ])
+
+    @mock.patch('charms_ceph.broker.update_service_permissions')
+    @mock.patch('charms_ceph.broker._build_service_groups')
+    @mock.patch('charms_ceph.broker.save_service')
+    @mock.patch('charms_ceph.broker.save_group')
+    @mock.patch('charms_ceph.broker.get_service_groups')
+    @mock.patch('charms_ceph.broker.get_group')
+    def test_handle_add_permissions_to_key_keeps_legacy_response(
+            self,
+            mock_get_group,
+            mock_get_service_groups,
+            mock_save_group,
+            mock_save_service,
+            mock_build_service_groups,
+            mock_update_service_permissions):
+        mock_get_group.return_value = {'pools': [], 'services': []}
+        mock_get_service_groups.return_value = {
+            'group_names': {},
+            'groups': {},
+        }
+        mock_build_service_groups.return_value = {'images': {'pools': []}}
+
+        resp = broker.handle_add_permissions_to_key(
+            request={'name': 'lxd', 'group': 'images'},
+            service='anbox',
+        )
+
+        self.assertEqual({'exit-code': 0}, resp)
+        mock_update_service_permissions.assert_called_once_with(
+            'lxd',
+            {
+                'group_names': {'rwx': ['images']},
+                'groups': {'images': {'pools': []}},
+            },
+            None,
+        )
+
+        # Silence unused patch warnings by asserting expected interaction.
+        mock_save_group.assert_called_once()
+        mock_save_service.assert_called_once()

--- a/ceph-proxy/unit_tests/test_ceph_broker.py
+++ b/ceph-proxy/unit_tests/test_ceph_broker.py
@@ -28,6 +28,11 @@ class CephBrokerTest(unittest.TestCase):
         mock_config.return_value = ''
         self.assertEqual('admin', broker.get_broker_service())
 
+    @mock.patch('charms_ceph.broker.config')
+    def test_get_broker_service_keeps_dotted_id(self, mock_config):
+        mock_config.return_value = 'radosgw.gateway'
+        self.assertEqual('radosgw.gateway', broker.get_broker_service())
+
     @mock.patch('charms_ceph.broker.handle_replicated_pool')
     @mock.patch('charms_ceph.broker.config')
     def test_process_requests_v1_uses_configured_admin_service(


### PR DESCRIPTION
# Description

Do not hard code `admin`  as a username. Tactical fix to make user configurable keys work. Falls back to admin if no custom name set

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests

## Contributor's Checklist

Please check that you have:

- [x] considered and tested upgrade scenarios from a previous stable version.
- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] added tests to verify effectiveness of this change.
