### PR TITLE
(stable/squid-jammy backport) fix: pin setuptools<82, testtools<2.8.0 and sync charms_ceph.utils for osd, proxy, radosgw

### DIFF
--- a/ceph-osd/lib/charms_ceph/utils.py
+++ b/ceph-osd/lib/charms_ceph/utils.py
@@ -2883,7 +2883,8 @@ def update_owner(path, recurse_dirs=True):
         secs=elapsed_time.total_seconds(), path=path), DEBUG)
 
 
-def get_osd_state(osd_num, osd_goal_state=None):
+def get_osd_state(osd_num, osd_goal_state=None, timeout=600,
+                  retry_interval=10):
     """Get OSD state or loop until OSD state matches OSD goal state.
 
     If osd_goal_state is None, just return the current OSD state.
@@ -2893,10 +2894,23 @@ def get_osd_state(osd_num, osd_goal_state=None):
     :param osd_num: the OSD id to get state for
     :param osd_goal_state: (Optional) string indicating state to wait for
                            Defaults to None
+    :param timeout: Maximum time in seconds to wait (default: 600)
+    :param retry_interval: Time in seconds between retries (default: 10)
     :returns: Returns a str, the OSD state.
     :rtype: str
     """
+    start_time = time.time()
+
     while True:
+        elapsed_time = time.time() - start_time
+
+        if elapsed_time > timeout:
+            log("Timeout waiting for OSD {} to reach state {}. "
+                "Elapsed time: {:.1f}s".format(
+                    osd_num, osd_goal_state or "any", elapsed_time),
+                level=WARNING)
+            return
+
         asok = "/var/run/ceph/ceph-osd.{}.asok".format(osd_num)
         cmd = [
             'ceph',
@@ -2909,7 +2923,9 @@ def get_osd_state(osd_num, osd_goal_state=None):
                                     .check_output(cmd)
                                     .decode('UTF-8')))
         except (subprocess.CalledProcessError, ValueError) as e:
-            log("{}".format(e), level=DEBUG)
+            log("Failed to get OSD {} state: {} (elapsed: {:.1f}s)".format(
+                osd_num, e, elapsed_time), level=ERROR)
+            time.sleep(retry_interval)
             continue
         osd_state = result['state']
         log("OSD {} state: {}, goal state: {}".format(
@@ -2918,7 +2934,7 @@ def get_osd_state(osd_num, osd_goal_state=None):
             return osd_state
         if osd_state == osd_goal_state:
             return osd_state
-        time.sleep(3)
+        time.sleep(retry_interval)
 
 
 def get_all_osd_states(osd_goal_states=None):

--- a/ceph-osd/test-requirements.txt
+++ b/ceph-osd/test-requirements.txt
@@ -27,3 +27,9 @@ git+https://opendev.org/openstack/tempest.git#egg=tempest
 
 croniter            # needed for charm-rabbitmq-server unit tests
 psutil
+
+# setuptools>=82 removed pkg_resources which is used by various packages.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0

--- a/ceph-proxy/lib/charms_ceph/utils.py
+++ b/ceph-proxy/lib/charms_ceph/utils.py
@@ -2875,7 +2875,8 @@ def update_owner(path, recurse_dirs=True):
         secs=elapsed_time.total_seconds(), path=path), DEBUG)
 
 
-def get_osd_state(osd_num, osd_goal_state=None):
+def get_osd_state(osd_num, osd_goal_state=None, timeout=600,
+                  retry_interval=10):
     """Get OSD state or loop until OSD state matches OSD goal state.
 
     If osd_goal_state is None, just return the current OSD state.
@@ -2885,10 +2886,23 @@ def get_osd_state(osd_num, osd_goal_state=None):
     :param osd_num: the OSD id to get state for
     :param osd_goal_state: (Optional) string indicating state to wait for
                            Defaults to None
+    :param timeout: Maximum time in seconds to wait (default: 600)
+    :param retry_interval: Time in seconds between retries (default: 10)
     :returns: Returns a str, the OSD state.
     :rtype: str
     """
+    start_time = time.time()
+
     while True:
+        elapsed_time = time.time() - start_time
+
+        if elapsed_time > timeout:
+            log("Timeout waiting for OSD {} to reach state {}. "
+                "Elapsed time: {:.1f}s".format(
+                    osd_num, osd_goal_state or "any", elapsed_time),
+                level=WARNING)
+            return
+
         asok = "/var/run/ceph/ceph-osd.{}.asok".format(osd_num)
         cmd = [
             'ceph',
@@ -2901,7 +2915,9 @@ def get_osd_state(osd_num, osd_goal_state=None):
                                     .check_output(cmd)
                                     .decode('UTF-8')))
         except (subprocess.CalledProcessError, ValueError) as e:
-            log("{}".format(e), level=DEBUG)
+            log("Failed to get OSD {} state: {} (elapsed: {:.1f}s)".format(
+                osd_num, e, elapsed_time), level=ERROR)
+            time.sleep(retry_interval)
             continue
         osd_state = result['state']
         log("OSD {} state: {}, goal state: {}".format(
@@ -2910,7 +2926,7 @@ def get_osd_state(osd_num, osd_goal_state=None):
             return osd_state
         if osd_state == osd_goal_state:
             return osd_state
-        time.sleep(3)
+        time.sleep(retry_interval)
 
 
 def get_all_osd_states(osd_goal_states=None):

--- a/ceph-proxy/test-requirements.txt
+++ b/ceph-proxy/test-requirements.txt
@@ -48,3 +48,9 @@ pyopenssl<=22.0.0
 
 pydantic < 2
 cosl
+
+# setuptools>=82 removed pkg_resources which is used by various packages.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0

--- a/ceph-radosgw/lib/charms_ceph/utils.py
+++ b/ceph-radosgw/lib/charms_ceph/utils.py
@@ -2874,7 +2874,8 @@ def update_owner(path, recurse_dirs=True):
         secs=elapsed_time.total_seconds(), path=path), DEBUG)
 
 
-def get_osd_state(osd_num, osd_goal_state=None):
+def get_osd_state(osd_num, osd_goal_state=None, timeout=600,
+                  retry_interval=10):
     """Get OSD state or loop until OSD state matches OSD goal state.
 
     If osd_goal_state is None, just return the current OSD state.
@@ -2884,10 +2885,23 @@ def get_osd_state(osd_num, osd_goal_state=None):
     :param osd_num: the OSD id to get state for
     :param osd_goal_state: (Optional) string indicating state to wait for
                            Defaults to None
+    :param timeout: Maximum time in seconds to wait (default: 600)
+    :param retry_interval: Time in seconds between retries (default: 10)
     :returns: Returns a str, the OSD state.
     :rtype: str
     """
+    start_time = time.time()
+
     while True:
+        elapsed_time = time.time() - start_time
+
+        if elapsed_time > timeout:
+            log("Timeout waiting for OSD {} to reach state {}. "
+                "Elapsed time: {:.1f}s".format(
+                    osd_num, osd_goal_state or "any", elapsed_time),
+                level=WARNING)
+            return
+
         asok = "/var/run/ceph/ceph-osd.{}.asok".format(osd_num)
         cmd = [
             'ceph',
@@ -2900,7 +2914,9 @@ def get_osd_state(osd_num, osd_goal_state=None):
                                     .check_output(cmd)
                                     .decode('UTF-8')))
         except (subprocess.CalledProcessError, ValueError) as e:
-            log("{}".format(e), level=DEBUG)
+            log("Failed to get OSD {} state: {} (elapsed: {:.1f}s)".format(
+                osd_num, e, elapsed_time), level=ERROR)
+            time.sleep(retry_interval)
             continue
         osd_state = result['state']
         log("OSD {} state: {}, goal state: {}".format(
@@ -2909,7 +2925,7 @@ def get_osd_state(osd_num, osd_goal_state=None):
             return osd_state
         if osd_state == osd_goal_state:
             return osd_state
-        time.sleep(3)
+        time.sleep(retry_interval)
 
 
 def get_all_osd_states(osd_goal_states=None):

--- a/ceph-radosgw/test-requirements.txt
+++ b/ceph-radosgw/test-requirements.txt
@@ -33,3 +33,9 @@ psutil
 
 # https://github.com/boto/boto3/issues/4392
 boto3<1.36.0
+
+# setuptools>=82 removed pkg_resources which is used by various packages.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0


### PR DESCRIPTION
setuptools>=82 removed pkg_resources breaking cliff and 
charm-tools. testtools 2.8.0 removed compat._b breaking stestr. 

Also syncs charms_ceph.utils with latest fixes.
