### PR TITLE
fix(ceph-osd): Resolve division by zero caused from division when no osds

### DIFF
--- a/ceph-osd/hooks/ceph_hooks.py
+++ b/ceph-osd/hooks/ceph_hooks.py
@@ -486,6 +486,10 @@ def get_osd_memory_target():
     if match:
         percentage = int(match.group(1)) / 100
         num_osds = len(kv().get("osd-devices", []))
+        if num_osds == 0:
+            log("tune-osd-memory-target is a percentage but no OSDs are"
+                " initialised yet, skipping", level=WARNING)
+            return ""
         osd_memory_target = int(get_total_ram() * percentage / num_osds)
         warn_if_memory_outside_bounds(osd_memory_target)
         return str(osd_memory_target)

--- a/ceph-osd/unit_tests/test_ceph_hooks.py
+++ b/ceph-osd/unit_tests/test_ceph_hooks.py
@@ -919,6 +919,65 @@ class CephHooksTestCase(unittest.TestCase):
     @patch.object(ceph_hooks, "get_total_ram")
     @patch.object(ceph_hooks, "kv")
     @patch.object(ceph_hooks, "log")
+    def test_get_osd_memory_target_percentage_no_osds(
+        self, mock_log, mock_kv, mock_total_ram, mock_config,
+    ):
+        """
+        Regression test for LP: #2147431
+        no ZeroDivisionError on fresh deploy.
+        """
+
+        mock_total_ram.return_value = 16 * 1024 * 1024 * 1024  # 16GB
+        mock_kv.return_value = {"osd-devices": []}
+
+        def config_func(k):
+            if k == "tune-osd-memory-target":
+                return "50%"
+            raise ValueError
+        mock_config.side_effect = config_func
+
+        target = ceph_hooks.get_osd_memory_target()
+
+        self.assertEqual(target, "")
+        mock_log.assert_called_with(
+            "tune-osd-memory-target is a percentage but no OSDs are"
+            " initialised yet, skipping",
+            level=ceph_hooks.WARNING,
+        )
+
+    @patch.object(ceph_hooks, "config")
+    @patch.object(ceph_hooks, "get_total_ram")
+    @patch.object(ceph_hooks, "kv")
+    @patch.object(ceph_hooks, "log")
+    def test_get_osd_memory_target_percentage_no_osd_key(
+        self, mock_log, mock_kv, mock_total_ram, mock_config,
+    ):
+        """
+        Regression test for LP: #2147431
+        no ZeroDivisionError on fresh deploy.
+        """
+        mock_total_ram.return_value = 16 * 1024 * 1024 * 1024  # 16GB
+        mock_kv.return_value = {}
+
+        def config_func(k):
+            if k == "tune-osd-memory-target":
+                return "50%"
+            raise ValueError
+        mock_config.side_effect = config_func
+
+        target = ceph_hooks.get_osd_memory_target()
+
+        self.assertEqual(target, "")
+        mock_log.assert_called_with(
+            "tune-osd-memory-target is a percentage but no OSDs are"
+            " initialised yet, skipping",
+            level=ceph_hooks.WARNING,
+        )
+
+    @patch.object(ceph_hooks, "config")
+    @patch.object(ceph_hooks, "get_total_ram")
+    @patch.object(ceph_hooks, "kv")
+    @patch.object(ceph_hooks, "log")
     def test_get_osd_memory_target_empty(
         self, mock_log, mock_kv, mock_total_ram,
         mock_config,


### PR DESCRIPTION
# Description

When tune-osd-memory-target is set to a percentage, the calculation divides by the number of initialised OSDs. On a fresh deployment the osd-devices list is empty, causing a ZeroDivisionError in the config-changed hook before osdize has run.

Return "" (leave osd_memory_target unset) when num_osds is zero. notify_osds_bootstrapped() will set the correct value once OSDs are registered.

Fixes https://bugs.launchpad.net/charm-ceph-osd/+bug/2147431

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

* Add two failing unit tests that reproduce the ZeroDivisionError in get_osd_memory_target() when tune-osd-memory-target is set to a percentage but no OSDs have been initialised yet (empty osd-devices list, and missing osd-devices key).
  * https://github.com/canonical/ceph-charms/actions/runs/24215196692/job/70693925119?pr=169
* Fix error, observe success

## Contributor's Checklist

Please check that you have:

- [x] considered and tested upgrade scenarios from a previous stable version.
- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
