### PR TITLE
Fix key rotation issue (based on #133)

### DIFF
--- a/ceph-mon/unit_tests/test_ceph_client_key_handling.py
+++ b/ceph-mon/unit_tests/test_ceph_client_key_handling.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from unittest.mock import MagicMock
+from test_utils import CharmTestCase
+
+
+class TestCephClientKeyHandling(CharmTestCase):
+    """Test cephx key handling, i.e., fix for LP#2125295."""
+
+    def setUp(self):
+        super(TestCephClientKeyHandling, self).setUp()
+
+    def test_reuse_existing_key_when_no_application_name(self):
+        """Test that existing key is reused when application-name not set.
+
+        When a client relation data doesn't include 'application-name',
+        reuse the existing key if one exists, rather than generating a
+        new key. This avoids a race condition where new units are
+        temporarily configured with the wrong key.
+        """
+
+        relation = MagicMock()
+        this_unit = MagicMock()
+        client_unit = MagicMock()
+
+        # Mock relational data
+        relation.data = {
+            this_unit: {'key': 'cephx-existing-key'},
+            client_unit: {}  # Client has no 'application-name' set yet
+        }
+
+        # Added logic from _handle_client_relation
+        ceph_key = relation.data[this_unit].get('key', None)
+        if 'application-name' not in relation.data[client_unit] and ceph_key:
+            key_to_use = ceph_key
+        else:
+            key_to_use = None
+
+        self.assertEqual(
+            key_to_use, 'cephx-existing-key',
+            "Use existing key when application-name not in client data")

--- a/ceph-mon/unit_tests/test_ceph_client_key_handling.py
+++ b/ceph-mon/unit_tests/test_ceph_client_key_handling.py
@@ -90,7 +90,7 @@ class TestCephClientKeyHandling(CharmTestCase):
         self.mock_get_named_key.return_value = 'rotated-key'
         self.mock_get_named_key.reset_mock()
 
-        # Client fires another relation-changed without setting application-name.
+        # Client fires relation-changed without setting application-name.
         self.harness.update_relation_data(
             rel_id, 'glance/0', {'ingress-address': '10.0.0.3'})
 
@@ -101,7 +101,7 @@ class TestCephClientKeyHandling(CharmTestCase):
             "Key must not change while client hasn't set application-name")
 
     def test_get_named_key_called_when_application_name_set(self):
-        """get_named_key is called with the application-name once client is ready.
+        """get_named_key is called with application-name once client is ready.
 
         Branch 3: when the client sets 'application-name' in its relation
         data, that signals it has finished configuring and the correct named
@@ -113,7 +113,7 @@ class TestCephClientKeyHandling(CharmTestCase):
         self.mock_get_named_key.return_value = 'named-key'
         self.mock_get_named_key.reset_mock()
 
-        # Client sets application-name (different from app name) signalling readiness.
+        # Client sets application-name to signal readiness.
         self.harness.update_relation_data(
             rel_id, 'glance/0', {'application-name': 'custom-nova'})
 

--- a/ceph-mon/unit_tests/test_ceph_client_key_handling.py
+++ b/ceph-mon/unit_tests/test_ceph_client_key_handling.py
@@ -12,42 +12,111 @@
 # limitations under the License.
 
 
-from unittest.mock import MagicMock
+import unittest.mock as mock
 from test_utils import CharmTestCase
+from ops.testing import Harness
+
+with mock.patch('charmhelpers.contrib.hardening.harden.harden') as mock_dec:
+    mock_dec.side_effect = (lambda *dargs, **dkwargs: lambda f:
+                            lambda *args, **kwargs: f(*args, **kwargs))
+    from src.charm import CephMonCharm
 
 
 class TestCephClientKeyHandling(CharmTestCase):
-    """Test cephx key handling, i.e., fix for LP#2125295."""
+    """Test cephx key rotation behaviour, covering the LP#2125295 race fix.
+
+    The three branches in _handle_client_relation:
+      1. No 'application-name' in client data AND no existing key
+         → call get_named_key (first join, no key yet)
+      2. No 'application-name' in client data AND key already exists
+         → reuse existing key (race condition guard - the LP#2125295 fix)
+      3. 'application-name' present in client data
+         → call get_named_key with that name (client is ready)
+    """
 
     def setUp(self):
-        super(TestCephClientKeyHandling, self).setUp()
+        super().setUp()
+        self.harness = Harness(CephMonCharm)
+        self.addCleanup(self.harness.cleanup)
+
+        patches = {
+            'send_osd_settings': mock.patch(
+                "src.charm.ceph_client.send_osd_settings"),
+            'get_public_addr': mock.patch(
+                "src.charm.ceph_client.get_public_addr"),
+            'get_rbd_features': mock.patch(
+                "src.charm.ceph_client.get_rbd_features"),
+            'get_named_key': mock.patch(
+                "src.charm.ceph_client.ceph.get_named_key"),
+            'ready_for_service': mock.patch.object(
+                CephMonCharm, "ready_for_service"),
+        }
+        for name, p in patches.items():
+            setattr(self, 'mock_' + name, p.start())
+            self.addCleanup(p.stop)
+
+        self.mock_get_public_addr.return_value = '127.0.0.1'
+        self.mock_get_rbd_features.return_value = None
+        self.mock_get_named_key.return_value = 'original-key'
+        self.mock_ready_for_service.return_value = True
+
+        self.harness.begin()
+        self.harness.set_leader()
+
+    def test_initial_join_calls_get_named_key(self):
+        """On first join (no key set yet), get_named_key is called.
+
+        Branch 1: ceph_key is None, so the else branch runs and
+        get_named_key is called to generate the initial key.
+        """
+        rel_id = self.harness.add_relation('client', 'glance')
+        self.harness.add_relation_unit(rel_id, 'glance/0')
+
+        self.mock_get_named_key.assert_called_once_with('glance')
+        unit_rel_data = self.harness.get_relation_data(rel_id, 'ceph-mon/0')
+        self.assertEqual(unit_rel_data['key'], 'original-key')
 
     def test_reuse_existing_key_when_no_application_name(self):
-        """Test that existing key is reused when application-name not set.
+        """Existing key is reused when client hasn't set application-name yet.
 
-        When a client relation data doesn't include 'application-name',
-        reuse the existing key if one exists, rather than generating a
-        new key. This avoids a race condition where new units are
-        temporarily configured with the wrong key.
+        Branch 2 (LP#2125295 fix): when a relation-changed fires before the
+        client hook has set 'application-name', the key already written by
+        ceph-mon must not be overwritten with a potentially rotated key.
         """
+        rel_id = self.harness.add_relation('client', 'glance')
+        self.harness.add_relation_unit(rel_id, 'glance/0')
 
-        relation = MagicMock()
-        this_unit = MagicMock()
-        client_unit = MagicMock()
+        # Simulate key rotation: get_named_key would now return a new key.
+        self.mock_get_named_key.return_value = 'rotated-key'
+        self.mock_get_named_key.reset_mock()
 
-        # Mock relational data
-        relation.data = {
-            this_unit: {'key': 'cephx-existing-key'},
-            client_unit: {}  # Client has no 'application-name' set yet
-        }
+        # Client fires another relation-changed without setting application-name.
+        self.harness.update_relation_data(
+            rel_id, 'glance/0', {'ingress-address': '10.0.0.3'})
 
-        # Added logic from _handle_client_relation
-        ceph_key = relation.data[this_unit].get('key', None)
-        if 'application-name' not in relation.data[client_unit] and ceph_key:
-            key_to_use = ceph_key
-        else:
-            key_to_use = None
-
+        self.mock_get_named_key.assert_not_called()
+        unit_rel_data = self.harness.get_relation_data(rel_id, 'ceph-mon/0')
         self.assertEqual(
-            key_to_use, 'cephx-existing-key',
-            "Use existing key when application-name not in client data")
+            unit_rel_data['key'], 'original-key',
+            "Key must not change while client hasn't set application-name")
+
+    def test_get_named_key_called_when_application_name_set(self):
+        """get_named_key is called with the application-name once client is ready.
+
+        Branch 3: when the client sets 'application-name' in its relation
+        data, that signals it has finished configuring and the correct named
+        key should be fetched using that name.
+        """
+        rel_id = self.harness.add_relation('client', 'glance')
+        self.harness.add_relation_unit(rel_id, 'glance/0')
+
+        self.mock_get_named_key.return_value = 'named-key'
+        self.mock_get_named_key.reset_mock()
+
+        # Client sets application-name (different from app name) signalling readiness.
+        self.harness.update_relation_data(
+            rel_id, 'glance/0', {'application-name': 'custom-nova'})
+
+        self.mock_get_named_key.assert_called_once_with('custom-nova')
+        unit_rel_data = self.harness.get_relation_data(rel_id, 'ceph-mon/0')
+        self.assertEqual(unit_rel_data['key'], 'named-key')


### PR DESCRIPTION
This is an addition to #133 that addresses the feedback on the testing. The code change and purpose is still the same.

Description
When new nova-compute units are added to Ceph-backed clouds, cephx keys are temporarily reverted back to the wrong (old) key value. This happens due to a race condition between the client hooks of nova-compute and ceph-mon. Details can be found in LP#2125295.

This patch ensures that ceph-mon checks whether the new unit has finished its configurations already and if not, keeps using the same key value.

Closes-Bug: #2125295

Type of change
Please delete options that are not relevant.

 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 CleanCode (Code refactor, test updates, does not introduce functional changes)
 Documentation update (Doc only change)
How Has This Been Tested?
I have set up a lab an tested the fix, I can no longer see the issue after the changes are applied.

NOTE: All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

Contributor's Checklist
Please check that you have:

 considered and tested upgrade scenarios from a previous stable version.
 self-reviewed the code in this PR.
 added code comments, particularly in hard-to-understand areas.
 updated the user documentation with corresponding changes.
 added tests to verify effectiveness of this change.