### PR TITLE
ceph-mon: mark optional relations as optional

### DIFF
--- a/ceph-mon/metadata.yaml
+++ b/ceph-mon/metadata.yaml
@@ -23,8 +23,10 @@ provides:
   nrpe-external-master:
     interface: nrpe-external-master
     scope: container
+    optional: true
   mds:
     interface: ceph-mds
+    optional: true
   admin:
     interface: ceph-admin
   client:
@@ -33,22 +35,29 @@ provides:
     interface: ceph-osd
   radosgw:
     interface: ceph-radosgw
+    optional: true
   rbd-mirror:
     interface: ceph-rbd-mirror
+    optional: true
   prometheus:
     interface: http
+    optional: true
   metrics-endpoint:
     interface: prometheus_scrape
+    optional: true
   dashboard:
     interface: ceph-dashboard
+    optional: true
   cos-agent:
     interface: cos_agent
+    optional: true
 
 requires:
   # DEPRECATED: The bootstrap-source relation is deprecated and will be
   # removed in the Umbrella release.
   bootstrap-source:
     interface: ceph-bootstrap
+    optional: true
 resources:
   alert-rules:
     type: file


### PR DESCRIPTION
Mark relations that are optional for the charm to function as `optional: true` in metadata.yaml.

**requires**
- `bootstrap-source`: only used for the "no-bootstrap" workflow (joining an existing cluster), gated on `config('no-bootstrap')`. Already deprecated upstream with removal planned for the Umbrella release.

**provides**
- `nrpe-external-master`, `mds`, `radosgw`, `rbd-mirror`, `prometheus`, `metrics-endpoint`, `dashboard`, `cos-agent`: each activates only on relation events and does not block when absent.

`osd`, `client`, and `admin` are left unchanged.