### PR TITLE
ceph-osd: mark optional relations as optional

### DIFF
--- a/ceph-osd/metadata.yaml
+++ b/ceph-osd/metadata.yaml
@@ -5,6 +5,7 @@ provides:
   nrpe-external-master:
     interface: nrpe-external-master
     scope: container
+    optional: true
 tags:
 - openstack
 - storage
@@ -27,6 +28,7 @@ requires:
     interface: ceph-osd
   secrets-storage:
     interface: vault-kv
+    optional: true
 storage:
   osd-devices:
     type: block


### PR DESCRIPTION
Mark relations that are optional for the charm to function as `optional: true` in metadata.yaml.

**requires**
- `secrets-storage`: only used when OSD disk encryption via Vault is configured (`osd-encrypt=True` and `osd-encrypt-keymanager=vault`). All vault code is gated behind `use_vaultlocker()`, which returns False unless both options are explicitly set. Default is `osd-encrypt=False`.

**provides**
- `nrpe-external-master`: NRPE monitoring subordinate, activates only on relation events and does not block when absent.