### PR TITLE
docs: add AGENTS.md with conventions and commands for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,3 @@ Per-charm, from the repo root. All nine charms expose the same envs:
 tox -c <charm-dir> -e pep8     # lint (flake8)
 tox -c <charm-dir> -e py3      # unit tests (stestr)
 ```
-
-## Integration / functional tests
-
-**Do not run integration, functional, or zaza (`func`, `func-smoke`, `func-dev`, `integration`) targets locally.** They require a bootstrapped Juju controller, LXD, and self-hosted CI runners. They run from `.github/workflows/build-and-test.yml` (`functional-test`, `cos-integration-test`) and via the `terraform-integration` env when explicitly invoked. If a change needs functional coverage, note it and let CI run it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+## Layout
+
+- Monorepo. Each charm lives in its own top-level directory (`ceph-mon/`, `ceph-osd/`, `ceph-radosgw/`, `ceph-fs/`, `ceph-dashboard/`, `ceph-nfs/`, `ceph-nvme/`, `ceph-proxy/`, `ceph-rbd-mirror/`) with its own `tox.ini`, `charmcraft.yaml`, `src/`, `unit_tests/`, `tests/`.
+- `charms.ceph/` — shared Python library (`charms_ceph`) vendored into each charm at build time. Edit here, not inside an individual charm's `lib/`.
+- `constraints/` — shared pip constraint files used by functional/integration envs.
+- `terraform/` — top-level Terraform module composing per-charm leaf modules under `<charm>/terraform/`.
+- `tests/` at repo root — shared scripts (e.g. `tests/scripts/actionutils.sh`) used by CI, not a test suite.
+
+## Commit conventions
+
+- Commits must be signed off (`Signed-off-by:` trailer) **by the human**. Agents must never add a `Signed-off-by:` trailer on the human's behalf — the DCO sign-off is an attestation only the human can make.
+- Agents must include an `Assisted-by:` trailer identifying the agent and model.
+- Order trailers as: `Assisted-by:` first, then the human's `Signed-off-by:` last (added by the human).
+
+Format:
+
+```
+Assisted-by: AGENT_NAME:MODEL_VERSION
+```
+
+- `AGENT_NAME` — the AI tool or framework (e.g. `claude-code`, `opencode`, `codex`, `pi`, …).
+- `MODEL_VERSION` — the specific model version used (e.g. `claude-sonnet-4-6`, `gpt-5.5`).
+
+Example:
+
+```
+Assisted-by: opencode:gpt-5.5
+```
+
+Other commit rules:
+
+- Commit messages must be ASCII only.
+- Keep PRs small and focused; don't mix trivial and controversial changes.
+- Squash into logical commits (API / docs / CLI / daemon / tests / CI) for non-trivial PRs.
+- Maintain a linear git history.
+
+## Build
+
+From the repo root, build a single charm:
+
+```
+tox -c <charm-dir> -e build
+```
+
+This runs `charmcraft clean && charmcraft -v pack && ./rename.sh`. Requires `charmcraft` installed (`sudo snap install charmcraft --classic`).
+
+## Unit tests and lint
+
+Per-charm, from the repo root. All nine charms expose the same envs:
+
+```
+tox -c <charm-dir> -e pep8     # lint (flake8)
+tox -c <charm-dir> -e py3      # unit tests (stestr)
+```
+
+## Integration / functional tests
+
+**Do not run integration, functional, or zaza (`func`, `func-smoke`, `func-dev`, `integration`) targets locally.** They require a bootstrapped Juju controller, LXD, and self-hosted CI runners. They run from `.github/workflows/build-and-test.yml` (`functional-test`, `cos-integration-test`) and via the `terraform-integration` env when explicitly invoked. If a change needs functional coverage, note it and let CI run it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
# Description

Add a terse AGENTS.md at the repo root capturing the conventions and commands an agent needs before reading the code: layout, commit trailers (Assisted-by + human-added Signed-off-by), build/lint/unit test invocations, and a list of integration targets that must not run locally. Add a one-line CLAUDE.md that includes AGENTS.md so Claude Code picks up the same guidance.

## Type of change

- [x] Documentation update (Doc only change)

## Contributor's Checklist

Please check that you have:

- [x] considered and tested upgrade scenarios from a previous stable version.
- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
