### PR TITLE
feat: add 'osd blocklist' command to default capabilities

### DIFF
--- a/ceph-proxy/hooks/ceph.py
+++ b/ceph-proxy/hooks/ceph.py
@@ -359,7 +359,8 @@ def get_mds_key(name):
 
 _default_caps = collections.OrderedDict([
     ('mon', ['allow r',
-             'allow command "osd blacklist"']),
+             'allow command "osd blacklist"',
+             'allow command "osd blocklist"']),
     ('osd', ['allow rwx']),
 ])
 


### PR DESCRIPTION
# Description

Adding osd blocklist to default caps which is used to create the caps initially when relations are added
This is required for backward compatibility as the cap changed from 'blacklist' to 'blocklist' in recent ceph versions

This is in extension to the previous change here - https://github.com/canonical/ceph-charms/commit/bc8c82da7aa10ba1c6fa274cdeb9bad9d4802984, which did not accomodate for the change in hooks/ceph.py which is invoked a the time of the creation of relations

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Created a charm locally and verified that on adding relation between cinder-ceph and ceph-proxy charms, osd-blocklist is added to the caps. Attached images of the caps with the production charm vs the current one on local
<img width="1838" height="891" alt="local_charm" src="https://github.com/user-attachments/assets/4650a943-6003-4c6d-99c6-af24b5d039a6" />
<img width="1838" height="889" alt="charmhub_charm" src="https://github.com/user-attachments/assets/2a56cf72-9e17-46e7-814d-6020131c11de" />

## Contributor's Checklist

Please check that you have:

- [x] considered and tested upgrade scenarios from a previous stable version.
- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
