### PR TITLE
Backport (#168) OTel incorrect variable to stable/squid-jammy

### DIFF
--- a/ceph-mon/src/ceph_metrics.py
+++ b/ceph-mon/src/ceph_metrics.py
@@ -215,7 +215,7 @@ class CephCOSAgentProvider(cos_agent.COSAgentProvider):
                         "regex": "(.+)",
                         "target_label": "instance",
                         "action": "replace",
-                        "replacement": "${1}",
+                        "replacement": "$1",
                     },
                     {   # tack on the domain to the instance label to make it
                         # conform to grafana-agent's node-exporter expectations
@@ -223,7 +223,7 @@ class CephCOSAgentProvider(cos_agent.COSAgentProvider):
                         "regex": "(.*)",
                         "target_label": "instance",
                         "action": "replace",
-                        "replacement": "${1}." + domain,
+                        "replacement": "$1." + domain,
                     },
                 ]
             },


### PR DESCRIPTION
# Description

opentelemetry-collector-operator fails to relate with:
  Error: failed to get config: cannot resolve the configuration:
  environment variable "1"

The ${1} syntax in metric_relabel_configs replacement values is interpreted as an environment variable reference by the OTel collector. Use bare $1 instead, which is the correct Prometheus relabeling syntax.

Backport of #168 to stable/squid-jammy. On this branch the relabeling config lives in ceph-mon/src/ceph_metrics.py rather than the ceph_cos_agent.py library used on main.

Fixes #141

Selective fix since #168 containt large CI changea
