### PR TITLE
feat: add 'osd blocklist' command to default capabilities

### DIFF
--- a/ceph-proxy/hooks/ceph.py
+++ b/ceph-proxy/hooks/ceph.py
@@ -353,7 +353,8 @@ def get_radosgw_key(name='radosgw.gateway'):
 
 _default_caps = collections.OrderedDict([
     ('mon', ['allow r',
-             'allow command "osd blacklist"']),
+             'allow command "osd blacklist"',
+             'allow command "osd blocklist"']),
     ('osd', ['allow rwx']),
 ])
 


### PR DESCRIPTION
Backporting addition of 'allow command "osd blocklist"' to stable/quincy