### PR TITLE
feat: add 'osd blocklist' command to default capabilities

### DIFF
--- a/ceph-proxy/hooks/ceph.py
+++ b/ceph-proxy/hooks/ceph.py
@@ -359,7 +359,8 @@ def get_mds_key(name):
 
 _default_caps = collections.OrderedDict([
     ('mon', ['allow r',
-             'allow command "osd blacklist"']),
+             'allow command "osd blacklist"',
+             'allow command "osd blocklist"']),
     ('osd', ['allow rwx']),
 ])
 


### PR DESCRIPTION
Backport addition of 'allow command "osd blocklist"' to stable/squid-jammy