### PR TITLE
fix: lvm counting with encrypted devices

### DIFF
--- a/ceph-osd/lib/charms_ceph/utils.py
+++ b/ceph-osd/lib/charms_ceph/utils.py
@@ -1504,9 +1504,24 @@ def get_lvs(dev):
     :raises subprocess.CalledProcessError: in the event that any supporting
                                            operation failed.
     :returns: list: List of logical volumes provided by the block device
+
+    When the device is a LUKS encrypted volume (e.g. a vaultlocker
+    encrypted bluestore wal/db utility device) the LVM physical volume
+    lives on the decrypted /dev/mapper/crypt-<uuid> device rather than
+    on the raw block device. In that case the PV inspection is redirected
+    to the mapper device so that the logical volumes are correctly
+    enumerated, otherwise get_lvs() would always return an empty list for
+    encrypted devices and all wal/db LVs would be allocated onto a single
+    utility device (LP: #1821454).
     """
     if not lvm.is_lvm_physical_volume(dev):
-        return []
+        luks_uuid = _luks_uuid(dev)
+        if not luks_uuid:
+            return []
+        mapper_dev = '/dev/mapper/crypt-{}'.format(luks_uuid)
+        if not lvm.is_lvm_physical_volume(mapper_dev):
+            return []
+        dev = mapper_dev
     vg_name = lvm.list_lvm_volume_group(dev)
     return lvm.list_logical_volumes('vg_name={}'.format(vg_name))
 

--- a/ceph-proxy/lib/charms_ceph/utils.py
+++ b/ceph-proxy/lib/charms_ceph/utils.py
@@ -1498,9 +1498,24 @@ def get_lvs(dev):
     :raises subprocess.CalledProcessError: in the event that any supporting
                                            operation failed.
     :returns: list: List of logical volumes provided by the block device
+
+    When the device is a LUKS encrypted volume (e.g. a vaultlocker
+    encrypted bluestore wal/db utility device) the LVM physical volume
+    lives on the decrypted /dev/mapper/crypt-<uuid> device rather than
+    on the raw block device. In that case the PV inspection is redirected
+    to the mapper device so that the logical volumes are correctly
+    enumerated, otherwise get_lvs() would always return an empty list for
+    encrypted devices and all wal/db LVs would be allocated onto a single
+    utility device (LP: #1821454).
     """
     if not lvm.is_lvm_physical_volume(dev):
-        return []
+        luks_uuid = _luks_uuid(dev)
+        if not luks_uuid:
+            return []
+        mapper_dev = '/dev/mapper/crypt-{}'.format(luks_uuid)
+        if not lvm.is_lvm_physical_volume(mapper_dev):
+            return []
+        dev = mapper_dev
     vg_name = lvm.list_lvm_volume_group(dev)
     return lvm.list_logical_volumes('vg_name={}'.format(vg_name))
 

--- a/ceph-radosgw/lib/charms_ceph/utils.py
+++ b/ceph-radosgw/lib/charms_ceph/utils.py
@@ -1498,9 +1498,24 @@ def get_lvs(dev):
     :raises subprocess.CalledProcessError: in the event that any supporting
                                            operation failed.
     :returns: list: List of logical volumes provided by the block device
+
+    When the device is a LUKS encrypted volume (e.g. a vaultlocker
+    encrypted bluestore wal/db utility device) the LVM physical volume
+    lives on the decrypted /dev/mapper/crypt-<uuid> device rather than
+    on the raw block device. In that case the PV inspection is redirected
+    to the mapper device so that the logical volumes are correctly
+    enumerated, otherwise get_lvs() would always return an empty list for
+    encrypted devices and all wal/db LVs would be allocated onto a single
+    utility device (LP: #1821454).
     """
     if not lvm.is_lvm_physical_volume(dev):
-        return []
+        luks_uuid = _luks_uuid(dev)
+        if not luks_uuid:
+            return []
+        mapper_dev = '/dev/mapper/crypt-{}'.format(luks_uuid)
+        if not lvm.is_lvm_physical_volume(mapper_dev):
+            return []
+        dev = mapper_dev
     vg_name = lvm.list_lvm_volume_group(dev)
     return lvm.list_logical_volumes('vg_name={}'.format(vg_name))
 

--- a/charms.ceph/charms_ceph/utils.py
+++ b/charms.ceph/charms_ceph/utils.py
@@ -1504,9 +1504,24 @@ def get_lvs(dev):
     :raises subprocess.CalledProcessError: in the event that any supporting
                                            operation failed.
     :returns: list: List of logical volumes provided by the block device
+
+    When the device is a LUKS encrypted volume (e.g. a vaultlocker
+    encrypted bluestore wal/db utility device) the LVM physical volume
+    lives on the decrypted /dev/mapper/crypt-<uuid> device rather than
+    on the raw block device. In that case the PV inspection is redirected
+    to the mapper device so that the logical volumes are correctly
+    enumerated, otherwise get_lvs() would always return an empty list for
+    encrypted devices and all wal/db LVs would be allocated onto a single
+    utility device (LP: #1821454).
     """
     if not lvm.is_lvm_physical_volume(dev):
-        return []
+        luks_uuid = _luks_uuid(dev)
+        if not luks_uuid:
+            return []
+        mapper_dev = '/dev/mapper/crypt-{}'.format(luks_uuid)
+        if not lvm.is_lvm_physical_volume(mapper_dev):
+            return []
+        dev = mapper_dev
     vg_name = lvm.list_lvm_volume_group(dev)
     return lvm.list_logical_volumes('vg_name={}'.format(vg_name))
 

--- a/charms.ceph/unit_tests/test_utils.py
+++ b/charms.ceph/unit_tests/test_utils.py
@@ -1978,6 +1978,46 @@ class CephFindLeastUsedDeviceTestCase(unittest.TestCase):
         )
         _get_lvs.assert_called()
 
+    @patch.object(utils, '_luks_uuid')
+    @patch.object(utils, 'lvm')
+    def test_find_least_used_utility_device_luks_lvs(self, _lvm, _luks_uuid):
+        # Regression test for LP: #1821454. With vaultlocker encrypted
+        # utility devices the PV lives on the mapper device, so get_lvs()
+        # must follow the raw->mapper redirect. Without it every device
+        # reports zero LVs and find_least_used_utility_device() always
+        # returns the first device, collapsing all wal/db LVs onto one
+        # utility device.
+        uuids = {
+            '/dev/sdb': 'uuid-sdb',
+            '/dev/sdc': 'uuid-sdc',
+            '/dev/sdd': 'uuid-sdd',
+        }
+        # NOTE: list_logical_volumes is invoked with a 'vg_name=<vg>'
+        # select string and the existing test convention strips that prefix
+        # with str.lstrip('vg_name=') which strips *characters*, so vg names
+        # must not start with any of v/g/_/n/a/m/e/=.
+        vgs = {
+            '/dev/mapper/crypt-uuid-sdb': 'cephdbsdb',
+            '/dev/mapper/crypt-uuid-sdc': 'cephdbsc',
+            '/dev/mapper/crypt-uuid-sdd': 'cephdbsdd',
+        }
+        lv_lists = {
+            'cephdbsdb': ['lv', 'lv', 'lv'],
+            'cephdbsc': [],
+            'cephdbsdd': ['lv'],
+        }
+        _luks_uuid.side_effect = lambda d: uuids.get(d)
+        _lvm.is_lvm_physical_volume.side_effect = lambda d: d in vgs
+        _lvm.list_lvm_volume_group.side_effect = lambda d: vgs.get(d)
+        _lvm.list_logical_volumes.side_effect = (
+            lambda sel: lv_lists.get(sel.lstrip('vg_name='), []))
+        # sdc has zero LVs and must be selected; without the fix sdb (the
+        # first device, with 3 LVs) would always be returned.
+        self.assertEqual(
+            utils.find_least_used_utility_device(
+                ['/dev/sdb', '/dev/sdc', '/dev/sdd'], lvs=True),
+            '/dev/sdc')
+
 
 class CephGetLVSTestCase(unittest.TestCase):
 
@@ -2018,13 +2058,48 @@ class CephGetLVSTestCase(unittest.TestCase):
         )
         _lvm.list_logical_volumes.assert_called_with('vg_name=missingvg')
 
+    @patch.object(utils, '_luks_uuid')
     @patch.object(utils, 'lvm')
-    def test_get_lvs_no_pv(self, _lvm):
+    def test_get_lvs_no_pv(self, _lvm, _luks_uuid):
+        _lvm.is_lvm_physical_volume.return_value = False
+        _luks_uuid.return_value = None
+        self.assertEqual(utils.get_lvs('/dev/sdb'), [])
+        _lvm.is_lvm_physical_volume.assert_called_with('/dev/sdb')
+        _luks_uuid.assert_called_with('/dev/sdb')
+
+    @patch.object(utils, '_luks_uuid')
+    @patch.object(utils, 'lvm')
+    def test_get_lvs_luks_encrypted(self, _lvm, _luks_uuid):
+        # A vaultlocker encrypted utility device: the raw device is not a PV
+        # but the LVM PV/VG/LVs live on the decrypted mapper device.
+        luks_uuid = '5e1e4c89-4f68-4b9a-bd93-e25eec34e80f'
+        mapper_dev = '/dev/mapper/crypt-{}'.format(luks_uuid)
+        _luks_uuid.return_value = luks_uuid
+        _lvm.is_lvm_physical_volume.side_effect = lambda d: d == mapper_dev
+        _lvm.list_lvm_volume_group.return_value = 'testvg'
+        _lvm.list_logical_volumes.side_effect = (
+            lambda vg: self._lvs.get(vg.lstrip('vg_name='), [])
+        )
+        self.assertEqual(utils.get_lvs('/dev/sdb'), self._lvs['testvg'])
+        # PV is inspected on the raw device first, then on the mapper.
+        _lvm.is_lvm_physical_volume.assert_has_calls(
+            [call('/dev/sdb'), call(mapper_dev)])
+        _luks_uuid.assert_called_with('/dev/sdb')
+        _lvm.list_lvm_volume_group.assert_called_with(mapper_dev)
+        _lvm.list_logical_volumes.assert_called_with('vg_name=testvg')
+
+    @patch.object(utils, '_luks_uuid')
+    @patch.object(utils, 'lvm')
+    def test_get_lvs_luks_not_yet_pv(self, _lvm, _luks_uuid):
+        # LUKS device whose mapper has not been initialised as a PV yet.
+        luks_uuid = '5e1e4c89-4f68-4b9a-bd93-e25eec34e80f'
+        mapper_dev = '/dev/mapper/crypt-{}'.format(luks_uuid)
+        _luks_uuid.return_value = luks_uuid
         _lvm.is_lvm_physical_volume.return_value = False
         self.assertEqual(utils.get_lvs('/dev/sdb'), [])
-        _lvm.is_lvm_physical_volume.assert_called_with(
-            '/dev/sdb'
-        )
+        _lvm.is_lvm_physical_volume.assert_has_calls(
+            [call('/dev/sdb'), call(mapper_dev)])
+        _luks_uuid.assert_called_with('/dev/sdb')
 
     @patch.object(utils, 'log')
     def test_is_pristine_disk(self, _log):


### PR DESCRIPTION
# Description

get_lvs(dev) checks whether dev is an LVM physical volume. For a LUKS-encrypted utility device the LVM PV actually lives on the decrypted /dev/mapper/crypt-<uuid> device, not the raw block device. So is_lvm_physical_volume(dev) returns False, get_lvs() returns [], and find_least_used_utility_device() sees every encrypted device as having zero LVs, always picking the first one and stacking all wal/db LVs onto a single utility device.

Fix: when the raw device isn't a PV, it now:
1. Looks up the LUKS UUID via the existing _luks_uuid(dev) helper,
2. Returns [] if there's no LUKS UUID,
3. Builds the /dev/mapper/crypt-<uuid> path and re-checks is_lvm_physical_volume on it,
4. If that's a PV, redirects PV/VG/LV enumeration to the mapper device.

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes https://bugs.launchpad.net/charm-ceph-osd/+bug/1821454

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

unit tests

## Contributor's Checklist

Please check that you have:

- [x] considered and tested upgrade scenarios from a previous stable version.
- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] added tests to verify effectiveness of this change.
