### PR TITLE
ceph-nvme: fix create-endpoint failure on high-core-count servers

### DIFF
--- a/ceph-nvme/config.yaml
+++ b/ceph-nvme/config.yaml
@@ -7,6 +7,16 @@ options:
       an integer, which specifies the number of cores, or a squared-bracketed
       list of CPU id's. By default, half the CPU cores will be used.
 
+      SPDK iobuf pool sizes are scaled automatically based on the number
+      of cores selected. More cores increase memory consumption but improve
+      throughput. Recommended values by workload:
+        - PoC / low IOPS (<10,000): 4 cores minimum
+        - Moderate IOPS: 8-16 cores
+        - High IOPS (200,000-300,000): 25-30+ cores
+      At least 8 GB of RAM (via nr-hugepages) should be dedicated per
+      gateway instance. When using many cores, ensure nr-hugepages is
+      sized accordingly.
+
   proxy-port:
     type: int
     default: 64321
@@ -23,7 +33,15 @@ options:
     type: int
     default: 2048
     description: |
-      The amount of hugepages to use. If set to 0, don't use them.
+      The number of 2 MB hugepages to reserve. If set to 0, hugepages are
+      disabled and SPDK runs with regular memory (expect reduced performance).
+      At least 8 GB (4096 pages) per gateway instance is recommended.
+
+      Recommended sizing by cpuset scale:
+        - 4 cores: 2048 (4 GB) minimum
+        - 8-16 cores: 4096 (8 GB)
+        - 25-30 cores: 8192-16384 (16-32 GB)
+      Insufficient hugepages may cause SPDK buffer allocation failures.
 
   discovery-port:
     type: int

--- a/ceph-nvme/src/nvmf.py
+++ b/ceph-nvme/src/nvmf.py
@@ -46,6 +46,12 @@ def main():
     cpuset = utils.compute_cpuset(config.get('cpuset'))
     args.extend(['-m', str(hex(utils.compute_cpumask(cpuset)))])
 
+    # Start in wait-for-rpc mode so that the proxy can configure
+    # iobuf pool sizes via iobuf_set_options RPC before SPDK
+    # completes initialization.  This is required because SPDK v24.05
+    # does not expose iobuf pool sizing as CLI flags.
+    args.append('--wait-for-rpc')
+
     # Replace the current process with a call to the target.
     os.execv(xname, args)
 

--- a/ceph-nvme/src/proxy.py
+++ b/ceph-nvme/src/proxy.py
@@ -99,16 +99,20 @@ class ProxyCreateEndpoint:
             self._check_reply(payload, proxy)
             cleanup.append(rpc.nvmf_delete_subsystem(nqn=nqn))
 
+            # Add namespace before listener so the subsystem is not yet
+            # in active/listening state, which causes add_ns to fail on
+            # some SPDK versions.
+            payload = rpc.nvmf_subsystem_add_ns(
+                nqn=nqn,
+                namespace=proxy.ns_dict(self.bdev_name, nqn))
+            self._check_reply(payload, proxy)
+
             self._add_listener(
                 proxy, cleanup,
                 nqn=nqn,
                 listen_address=dict(trtype='tcp', traddr=self.msg['addr'],
                                     trsvcid=self.msg.get('port')))
-
-            payload = rpc.nvmf_subsystem_add_ns(
-                nqn=nqn,
-                namespace=proxy.ns_dict(self.bdev_name, nqn))
-            return self._check_reply(payload, proxy)
+            return payload
         except Exception:
             for call in reversed(cleanup):
                 proxy.msgloop(call)
@@ -204,6 +208,7 @@ class Proxy:
         self.receiver = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.receiver.bind(('0.0.0.0', config['proxy-port']))
         self._connect(rpc_path)
+        self._startup_init(config)
         wdir = os.path.dirname(config_path)
         self.key_dir = os.path.join(wdir, 'keys')
         self.local_state = self._read_local_state(wdir)
@@ -250,6 +255,29 @@ class Proxy:
                 return
 
             time.sleep(0.1)
+
+    def _startup_init(self, config):
+        """Configure iobuf pools and complete SPDK initialization.
+
+        nvmf_tgt is started with --wait-for-rpc, so we must call
+        iobuf_set_options (a startup-only RPC) before framework_start_init.
+        """
+        cpuset = utils.compute_cpuset(config.get('cpuset', ''))
+        num_cores = len(cpuset)
+        # SPDK defaults (1024 large, 8192 small) work reliably at 8 cores.
+        # Per-core ratios: 1024/8 = 128 large, 8192/8 = 1024 small.
+        large_pool = max(1024, num_cores * 128)
+        small_pool = max(8192, num_cores * 1024)
+
+        reply = self.msgloop(self.rpc.iobuf_set_options(
+            small_pool_count=small_pool,
+            large_pool_count=large_pool))
+        if self.is_error(reply):
+            logger.warning('iobuf_set_options failed: %s', reply)
+
+        reply = self.msgloop(self.rpc.framework_start_init())
+        if self.is_error(reply):
+            raise RuntimeError('framework_start_init failed: %s' % reply)
 
     def _read_local_state(self, wdir):
         fname = os.path.join(wdir, 'local.json')

--- a/ceph-nvme/unit_tests/utils.py
+++ b/ceph-nvme/unit_tests/utils.py
@@ -155,6 +155,12 @@ class MockSPDK:
     def spdk_kill_instance(self, **kwargs):
         self._init_vars()
 
+    def iobuf_set_options(self, **kwargs):
+        pass
+
+    def framework_start_init(self, **kwargs):
+        pass
+
     def loop(self, timeout=None):
         rd, _, _ = select.select([self.sock], [], [], timeout)
         if not rd:


### PR DESCRIPTION
Scale SPDK iobuf pool sizes proportionally to the number of cores in the cpuset to prevent buffer allocation exhaustion on large servers. The per-core ratios (128 large, 1024 small) are derived from SPDK defaults working reliably at 8 cores.

Reorder endpoint creation to add the namespace before the listener, avoiding "subsystem in active state" rejections on SPDK versions that disallow namespace addition after the subsystem starts listening.

Fixes LP#2158795.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [ ] Documentation update (Doc only change)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

## Contributor's Checklist

Please check that you have:

- [ ] considered and tested upgrade scenarios from a previous stable version.
- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [x] updated the user documentation with corresponding changes.
- [ ] added tests to verify effectiveness of this change.
