### PR TITLE
fix: Declare charms-ceph as a ceph-nfs build dependency

### DIFF
--- a/ceph-nfs/pyproject.toml
+++ b/ceph-nfs/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 requires-python = ">=3.10"
 dependencies = [
     "ops>=3.7.0",
+    "charms-ceph @ git+https://github.com/canonical/ceph-charms.git#subdirectory=charms.ceph",
     "charmhelpers @ git+https://github.com/juju/charm-helpers",
     "interface-ceph-client @ git+https://opendev.org/openstack/charm-ops-interface-ceph-client",
     "ops-openstack @ git+https://opendev.org/openstack/charm-ops-openstack",

--- a/ceph-nfs/uv.lock
+++ b/ceph-nfs/uv.lock
@@ -8,6 +8,7 @@ version = "0.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "charmhelpers" },
+    { name = "charms-ceph" },
     { name = "interface-ceph-client" },
     { name = "interface-hacluster" },
     { name = "netifaces" },
@@ -19,6 +20,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "charmhelpers", git = "https://github.com/juju/charm-helpers" },
+    { name = "charms-ceph", git = "https://github.com/canonical/ceph-charms.git?subdirectory=charms.ceph" },
     { name = "interface-ceph-client", git = "https://opendev.org/openstack/charm-ops-interface-ceph-client" },
     { name = "interface-hacluster", git = "https://opendev.org/openstack/charm-interface-hacluster" },
     { name = "netifaces", specifier = ">=0.11.0" },
@@ -37,6 +39,15 @@ dependencies = [
     { name = "netaddr" },
     { name = "pbr" },
     { name = "pyyaml" },
+]
+
+[[package]]
+name = "charms-ceph"
+version = "0.0.1.dev1"
+source = { git = "https://github.com/canonical/ceph-charms.git?subdirectory=charms.ceph#3e890ad332f8b60b159b0a7830195d32a6a6f21b" }
+dependencies = [
+    { name = "charmhelpers" },
+    { name = "pyudev" },
 ]
 
 [[package]]
@@ -251,6 +262,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "pyudev"
+version = "0.24.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/1d/8bdbf651de1002e8b58fbe817bee22b1e8bfcdd24341d42c3238ce9a75f4/pyudev-0.24.4.tar.gz", hash = "sha256:e788bb983700b1a84efc2e88862b0a51af2a995d5b86bc9997546505cf7b36bc", size = 56135, upload-time = "2025-10-08T17:26:58.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/51/3dc0cd6498b24dea3cdeaed648568e3ca7454d41334d840b114156d7479f/pyudev-0.24.4-py3-none-any.whl", hash = "sha256:b3b6b01c68e6fc628428cc45ff3fe6c277afbb5d96507f14473ddb4a6b959e00", size = 62784, upload-time = "2025-10-08T17:26:57.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

`ceph-nfs` fails its install hook on every branch:

```
File ".../src/charm.py", line 42, in <module>
    import charms_ceph.selog as selog
ModuleNotFoundError: No module named 'charms_ceph'
```

The charm imports `charms_ceph` but does not ship it.

`ceph-nfs` is packed with the charmcraft `uv` plugin, which reads deps from
`pyproject.toml` + `uv.lock`. The dependency was only in `requirements.txt`,
which the build ignores. Unit tests use `requirements.txt`, so they passed
while the published charm stayed broken.

Fix: add `charms-ceph` to `pyproject.toml` (like `ceph-mon` already does) and
re-lock. This pulls in `charms_ceph` and `pyudev` — the two things missing from
the broken charm.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Reproduced the failure by deploying `ch:ceph-nfs --channel latest/edge`
  (rev 339): install hook fails with `ModuleNotFoundError`. Log:
  `PR-ceph-nfs-edge-fails.log`. In CI:
  https://github.com/canonical/ceph-charms/actions/runs/28902882652/job/85981593545
- Packed the charm from this branch: it now ships `charms_ceph/selog.py` and
  `pyudev`.
- Deployed the packed charm: install hook passes, unit reaches
  `blocked: Missing relations: ceph-client`, nfs-ganesha installs, no
  `ModuleNotFoundError`.

> Note: the functional test deploys the *published* charm from `latest/edge`,
> so this must land and `latest/edge` be rebuilt before the ceph-nfs job goes
> green.

## Contributor's Checklist

- [x] considered and tested upgrade scenarios from a previous stable version.
- [x] self-reviewed the code in this PR.

[PR-ceph-nfs-edge-fails.log](https://github.com/user-attachments/files/29910295/PR-ceph-nfs-edge-fails.log)
