### PR TITLE
test: Give the mysql test machine cores and memory

### DIFF
--- a/ceph-mon/tests/bundles/noble-caracal.yaml
+++ b/ceph-mon/tests/bundles/noble-caracal.yaml
@@ -12,7 +12,7 @@ machines:
     constraints: cores=2 mem=6G root-disk=24G virt-type=virtual-machine
   '6':
     series: jammy
-    constraints: root-disk=12G virt-type=virtual-machine
+    constraints: cores=2 mem=4G root-disk=12G virt-type=virtual-machine
   '7':
 
 applications:

--- a/ceph-radosgw/tests/bundles/noble-caracal.yaml
+++ b/ceph-radosgw/tests/bundles/noble-caracal.yaml
@@ -18,7 +18,7 @@ machines:
    '6':
    '7':
      series: jammy
-     constraints: root-disk=12G virt-type=virtual-machine
+     constraints: cores=2 mem=4G root-disk=12G virt-type=virtual-machine
    '8':
 
 applications:


### PR DESCRIPTION
# Description

The `ceph-mon` and `ceph-radosgw` functional tests fail intermittently.
`mysql/0` errors with hooks timing out:

```
subprocess.TimeoutExpired: Command '['charmed-mysql.mysqlsh', ...]'
    timed out after 50 seconds
```

keystone then never finishes, and `ceph-radosgw` / `cinder` hang on
`Incomplete relations: identity`.

Both bundles pin mysql to a machine with only `root-disk` and
`virt-type=virtual-machine`. With no `cores`/`mem`, LXD gives it its VM default
of **1 vCPU / 1 GiB** (confirmed in crashdumps: `Brought up 1 CPU`,
`Memory: ~1GiB`). That is not enough for charmed-mysql, so `mysqlsh` exceeds the
timeouts hardcoded in the mysql charm lib.

Fix: give the machine `cores=2 mem=4G`, matching the other VMs in these bundles.
(`ceph-dashboard` gives mysql no placement, so it lands in a container sharing
the host's resources and never hits this.)

## Type of change

- [x] CleanCode (Code refactor, test updates, does not introduce functional changes)

## How Has This Been Tested?

Failing CI run: https://github.com/canonical/ceph-charms/actions/runs/28902882652
- ceph-radosgw: https://github.com/canonical/ceph-charms/actions/runs/28902882652/job/85981593398
- ceph-mon: https://github.com/canonical/ceph-charms/actions/runs/28902882652/job/85981593819

Root cause confirmed from those runs' crashdumps: mysql VM had 1 vCPU / 1 GiB,
and `mysqlsh` timed out. This change only enlarges the test machine; it does not
touch charm code. Needs a CI run to confirm the jobs go green.

## Contributor's Checklist

- [x] self-reviewed the code in this PR.
- [x] added tests to verify effectiveness of this change (test bundle change).