### PR TITLE
fix(ceph-rbd-mirror): drop charm-tools from pep8 env

### DIFF
--- a/ceph-rbd-mirror/src/test-requirements.txt
+++ b/ceph-rbd-mirror/src/test-requirements.txt
@@ -18,6 +18,12 @@ stestr>=2.2.0
 # https://github.com/mtreinish/stestr/issues/145
 cliff<3.0.0
 
+# setuptools>=82 removed pkg_resources which is used by cliff<3.0.0.
+setuptools<82
+
+# stestr uses testtools.compat._b which was removed in testtools 2.8.0.
+testtools<2.8.0
+
 # Dependencies of stestr. Newer versions use keywords that didn't exist in
 # python 3.5 yet (e.g. "ModuleNotFoundError")
 importlib-metadata<3.0.0; python_version < '3.6'

--- a/ceph-rbd-mirror/test-requirements.txt
+++ b/ceph-rbd-mirror/test-requirements.txt
@@ -9,6 +9,9 @@ stestr>=2.2.0
 # https://github.com/mtreinish/stestr/issues/145
 cliff<3.0.0
 
+# setuptools>=82 removed pkg_resources which is used by cliff<3.0.0.
+setuptools<82
+
 requests>=2.18.4
 charms.reactive
 

--- a/ceph-rbd-mirror/tox.ini
+++ b/ceph-rbd-mirror/tox.ini
@@ -83,7 +83,6 @@ commands = stestr run --slowest {posargs}
 [testenv:pep8]
 basepython = python3
 deps = flake8
-       charm-tools
 commands = flake8 {posargs} src unit_tests
 
 [testenv:cover]


### PR DESCRIPTION
Assisted-by: pi:z-ai/glm-5.2

