### PR TITLE
feat: additional terraform modules

### DIFF
--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -1,17 +1,22 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-name: Terraform integration tests
+name: Terraform core integration tests
 
 on:
   push:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: terraform-core-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  terraform-integration:
-    name: Terraform integration tests
+  terraform-core:
+    name: Terraform core integration tests
     runs-on: [self-hosted, linux, amd64, X64, xlarge, noble]
     timeout-minutes: 120
 
@@ -37,5 +42,8 @@ jobs:
         with:
           terraform_wrapper: false
 
-      - name: Run Terraform integration tests
-        run: tox -e terraform-integration
+      - name: Run Terraform core tests
+        run: |
+          tox -e terraform-integration -- \
+            -m "not slow" \
+            tests/integration/terraform

--- a/ceph-dashboard/terraform/locals.tf
+++ b/ceph-dashboard/terraform/locals.tf
@@ -1,0 +1,24 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+locals {
+  # Endpoint aliases are exported for composition by higher-level modules.
+  offers = {
+    for alias, offer in juju_offer.offers :
+    alias => offer.url
+  }
+
+  provides = {
+    grafana_dashboard = "grafana-dashboard"
+  }
+
+  requires = {
+    alertmanager_service = "alertmanager-service"
+    certificates         = "certificates"
+    dashboard            = "dashboard"
+    iscsi_dashboard      = "iscsi-dashboard"
+    loadbalancer         = "loadbalancer"
+    prometheus           = "prometheus"
+    radosgw_dashboard    = "radosgw-dashboard"
+  }
+}

--- a/ceph-dashboard/terraform/main.tf
+++ b/ceph-dashboard/terraform/main.tf
@@ -1,0 +1,22 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "ceph_dashboard" {
+  # Juju provider v1 uses model UUIDs rather than model names for targeting.
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "ceph-dashboard"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  # ceph-dashboard is a subordinate charm: it carries no units of its own and
+  # is colocated with a principal application via the dashboard relation. The
+  # units argument is intentionally omitted for subordinate applications.
+  config      = var.config
+  constraints = var.constraints
+  resources   = var.resources
+}

--- a/ceph-dashboard/terraform/offers.tf
+++ b/ceph-dashboard/terraform/offers.tf
@@ -1,0 +1,10 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_offer" "offers" {
+  for_each = toset(var.offered_endpoints)
+
+  application_name = juju_application.ceph_dashboard.name
+  endpoints        = [local.provides[each.value]]
+  model_uuid       = var.model_uuid
+}

--- a/ceph-dashboard/terraform/outputs.tf
+++ b/ceph-dashboard/terraform/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "application" {
+  description = "Object representing the deployed ceph-dashboard application."
+  value       = juju_application.ceph_dashboard
+}
+
+output "offers" {
+  description = "Map of exposed offer URLs keyed by endpoint key."
+  value       = local.offers
+}
+
+output "provides" {
+  description = "Map of provides endpoints keyed by relation alias."
+  value       = local.provides
+}
+
+output "requires" {
+  description = "Map of requires endpoints keyed by relation alias."
+  value       = local.requires
+}

--- a/ceph-dashboard/terraform/providers.tf
+++ b/ceph-dashboard/terraform/providers.tf
@@ -1,0 +1,5 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Provider requirements are declared in terraform.tf.
+# Intentionally no provider block: module consumers supply provider configuration.

--- a/ceph-dashboard/terraform/terraform.tf
+++ b/ceph-dashboard/terraform/terraform.tf
@@ -1,0 +1,13 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 1.0.0"
+    }
+  }
+}

--- a/ceph-dashboard/terraform/variables.tf
+++ b/ceph-dashboard/terraform/variables.tf
@@ -1,0 +1,64 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "ceph-dashboard"
+}
+
+variable "base" {
+  description = "Operating system base used for deployment, e.g. ubuntu@24.04."
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
+variable "channel" {
+  description = "Channel of the charm to deploy."
+  type        = string
+  default     = "squid/stable"
+}
+
+variable "config" {
+  description = "Application config options for ceph-dashboard."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = null
+}
+
+variable "model_uuid" {
+  description = "Reference to an existing Juju model UUID."
+  type        = string
+  nullable    = false
+}
+
+variable "offered_endpoints" {
+  description = "List of provided endpoint aliases to expose as Juju offers."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for alias in var.offered_endpoints :
+      contains(["grafana_dashboard"], alias)
+    ])
+    error_message = "offered_endpoints must only contain ceph-dashboard provides aliases."
+  }
+}
+
+variable "resources" {
+  description = "Resources to use with the application."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Revision number of the charm to deploy."
+  type        = number
+  default     = null
+}

--- a/ceph-fs/terraform/locals.tf
+++ b/ceph-fs/terraform/locals.tf
@@ -1,0 +1,19 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+locals {
+  # Endpoint aliases are exported for composition by higher-level modules.
+  offers = {
+    for alias, offer in juju_offer.offers :
+    alias => offer.url
+  }
+
+  provides = {
+    cephfs_share = "cephfs-share"
+    filesystem   = "filesystem"
+  }
+
+  requires = {
+    ceph_mds = "ceph-mds"
+  }
+}

--- a/ceph-fs/terraform/main.tf
+++ b/ceph-fs/terraform/main.tf
@@ -1,0 +1,20 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "ceph_fs" {
+  # Juju provider v1 uses model UUIDs rather than model names for targeting.
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "ceph-fs"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  resources   = var.resources
+  units       = var.units
+}

--- a/ceph-fs/terraform/offers.tf
+++ b/ceph-fs/terraform/offers.tf
@@ -1,0 +1,10 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_offer" "offers" {
+  for_each = toset(var.offered_endpoints)
+
+  application_name = juju_application.ceph_fs.name
+  endpoints        = [local.provides[each.value]]
+  model_uuid       = var.model_uuid
+}

--- a/ceph-fs/terraform/outputs.tf
+++ b/ceph-fs/terraform/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "application" {
+  description = "Object representing the deployed ceph-fs application."
+  value       = juju_application.ceph_fs
+}
+
+output "offers" {
+  description = "Map of exposed offer URLs keyed by endpoint key."
+  value       = local.offers
+}
+
+output "provides" {
+  description = "Map of provides endpoints keyed by relation alias."
+  value       = local.provides
+}
+
+output "requires" {
+  description = "Map of requires endpoints keyed by relation alias."
+  value       = local.requires
+}

--- a/ceph-fs/terraform/providers.tf
+++ b/ceph-fs/terraform/providers.tf
@@ -1,0 +1,5 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Provider requirements are declared in terraform.tf.
+# Intentionally no provider block: module consumers supply provider configuration.

--- a/ceph-fs/terraform/terraform.tf
+++ b/ceph-fs/terraform/terraform.tf
@@ -1,0 +1,13 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 1.0.0"
+    }
+  }
+}

--- a/ceph-fs/terraform/variables.tf
+++ b/ceph-fs/terraform/variables.tf
@@ -1,0 +1,70 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "ceph-fs"
+}
+
+variable "base" {
+  description = "Operating system base used for deployment, e.g. ubuntu@24.04."
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
+variable "channel" {
+  description = "Channel of the charm to deploy."
+  type        = string
+  default     = "squid/stable"
+}
+
+variable "config" {
+  description = "Application config options for ceph-fs."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = null
+}
+
+variable "model_uuid" {
+  description = "Reference to an existing Juju model UUID."
+  type        = string
+  nullable    = false
+}
+
+variable "offered_endpoints" {
+  description = "List of provided endpoint aliases to expose as Juju offers."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for alias in var.offered_endpoints :
+      contains(["cephfs_share", "filesystem"], alias)
+    ])
+    error_message = "offered_endpoints must only contain ceph-fs provides aliases."
+  }
+}
+
+variable "resources" {
+  description = "Resources to use with the application."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Revision number of the charm to deploy."
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units to deploy."
+  type        = number
+  default     = 1
+}

--- a/ceph-nfs/terraform/locals.tf
+++ b/ceph-nfs/terraform/locals.tf
@@ -1,0 +1,17 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+locals {
+  # Endpoint aliases are exported for composition by higher-level modules.
+  offers = {
+    for alias, offer in juju_offer.offers :
+    alias => offer.url
+  }
+
+  provides = {}
+
+  requires = {
+    ceph_client = "ceph-client"
+    ha          = "ha"
+  }
+}

--- a/ceph-nfs/terraform/main.tf
+++ b/ceph-nfs/terraform/main.tf
@@ -1,0 +1,20 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "ceph_nfs" {
+  # Juju provider v1 uses model UUIDs rather than model names for targeting.
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "ceph-nfs"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  resources   = var.resources
+  units       = var.units
+}

--- a/ceph-nfs/terraform/offers.tf
+++ b/ceph-nfs/terraform/offers.tf
@@ -1,0 +1,10 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_offer" "offers" {
+  for_each = toset(var.offered_endpoints)
+
+  application_name = juju_application.ceph_nfs.name
+  endpoints        = [local.provides[each.value]]
+  model_uuid       = var.model_uuid
+}

--- a/ceph-nfs/terraform/outputs.tf
+++ b/ceph-nfs/terraform/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "application" {
+  description = "Object representing the deployed ceph-nfs application."
+  value       = juju_application.ceph_nfs
+}
+
+output "offers" {
+  description = "Map of exposed offer URLs keyed by endpoint key."
+  value       = local.offers
+}
+
+output "provides" {
+  description = "Map of provides endpoints keyed by relation alias."
+  value       = local.provides
+}
+
+output "requires" {
+  description = "Map of requires endpoints keyed by relation alias."
+  value       = local.requires
+}

--- a/ceph-nfs/terraform/providers.tf
+++ b/ceph-nfs/terraform/providers.tf
@@ -1,0 +1,5 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Provider requirements are declared in terraform.tf.
+# Intentionally no provider block: module consumers supply provider configuration.

--- a/ceph-nfs/terraform/terraform.tf
+++ b/ceph-nfs/terraform/terraform.tf
@@ -1,0 +1,13 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 1.0.0"
+    }
+  }
+}

--- a/ceph-nfs/terraform/variables.tf
+++ b/ceph-nfs/terraform/variables.tf
@@ -1,0 +1,67 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "ceph-nfs"
+}
+
+variable "base" {
+  description = "Operating system base used for deployment, e.g. ubuntu@24.04."
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
+variable "channel" {
+  description = "Channel of the charm to deploy."
+  type        = string
+  default     = "squid/stable"
+}
+
+variable "config" {
+  description = "Application config options for ceph-nfs."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = null
+}
+
+variable "model_uuid" {
+  description = "Reference to an existing Juju model UUID."
+  type        = string
+  nullable    = false
+}
+
+variable "offered_endpoints" {
+  description = "List of provided endpoint aliases to expose as Juju offers. ceph-nfs has no provides endpoints, so this must remain empty."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.offered_endpoints) == 0
+    error_message = "ceph-nfs has no provides endpoints to offer; offered_endpoints must be empty."
+  }
+}
+
+variable "resources" {
+  description = "Resources to use with the application."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Revision number of the charm to deploy."
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units to deploy."
+  type        = number
+  default     = 1
+}

--- a/ceph-nvme/terraform/locals.tf
+++ b/ceph-nvme/terraform/locals.tf
@@ -1,0 +1,18 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+locals {
+  # Endpoint aliases are exported for composition by higher-level modules.
+  offers = {
+    for alias, offer in juju_offer.offers :
+    alias => offer.url
+  }
+
+  provides = {
+    admin_access = "admin-access"
+  }
+
+  requires = {
+    ceph_client = "ceph-client"
+  }
+}

--- a/ceph-nvme/terraform/main.tf
+++ b/ceph-nvme/terraform/main.tf
@@ -1,0 +1,20 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "ceph_nvme" {
+  # Juju provider v1 uses model UUIDs rather than model names for targeting.
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "ceph-nvme"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  resources   = var.resources
+  units       = var.units
+}

--- a/ceph-nvme/terraform/offers.tf
+++ b/ceph-nvme/terraform/offers.tf
@@ -1,0 +1,10 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_offer" "offers" {
+  for_each = toset(var.offered_endpoints)
+
+  application_name = juju_application.ceph_nvme.name
+  endpoints        = [local.provides[each.value]]
+  model_uuid       = var.model_uuid
+}

--- a/ceph-nvme/terraform/outputs.tf
+++ b/ceph-nvme/terraform/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "application" {
+  description = "Object representing the deployed ceph-nvme application."
+  value       = juju_application.ceph_nvme
+}
+
+output "offers" {
+  description = "Map of exposed offer URLs keyed by endpoint key."
+  value       = local.offers
+}
+
+output "provides" {
+  description = "Map of provides endpoints keyed by relation alias."
+  value       = local.provides
+}
+
+output "requires" {
+  description = "Map of requires endpoints keyed by relation alias."
+  value       = local.requires
+}

--- a/ceph-nvme/terraform/providers.tf
+++ b/ceph-nvme/terraform/providers.tf
@@ -1,0 +1,5 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Provider requirements are declared in terraform.tf.
+# Intentionally no provider block: module consumers supply provider configuration.

--- a/ceph-nvme/terraform/terraform.tf
+++ b/ceph-nvme/terraform/terraform.tf
@@ -1,0 +1,13 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 1.0.0"
+    }
+  }
+}

--- a/ceph-nvme/terraform/variables.tf
+++ b/ceph-nvme/terraform/variables.tf
@@ -1,0 +1,70 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "ceph-nvme"
+}
+
+variable "base" {
+  description = "Operating system base used for deployment, e.g. ubuntu@24.04."
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
+variable "channel" {
+  description = "Channel of the charm to deploy."
+  type        = string
+  default     = "squid/stable"
+}
+
+variable "config" {
+  description = "Application config options for ceph-nvme."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = null
+}
+
+variable "model_uuid" {
+  description = "Reference to an existing Juju model UUID."
+  type        = string
+  nullable    = false
+}
+
+variable "offered_endpoints" {
+  description = "List of provided endpoint aliases to expose as Juju offers."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for alias in var.offered_endpoints :
+      contains(["admin_access"], alias)
+    ])
+    error_message = "offered_endpoints must only contain ceph-nvme provides aliases."
+  }
+}
+
+variable "resources" {
+  description = "Resources to use with the application."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Revision number of the charm to deploy."
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units to deploy."
+  type        = number
+  default     = 1
+}

--- a/ceph-proxy/terraform/locals.tf
+++ b/ceph-proxy/terraform/locals.tf
@@ -1,0 +1,18 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+locals {
+  # Endpoint aliases are exported for composition by higher-level modules.
+  offers = {
+    for alias, offer in juju_offer.offers :
+    alias => offer.url
+  }
+
+  provides = {
+    client  = "client"
+    mds     = "mds"
+    radosgw = "radosgw"
+  }
+
+  requires = {}
+}

--- a/ceph-proxy/terraform/main.tf
+++ b/ceph-proxy/terraform/main.tf
@@ -1,0 +1,20 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "ceph_proxy" {
+  # Juju provider v1 uses model UUIDs rather than model names for targeting.
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "ceph-proxy"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  resources   = var.resources
+  units       = var.units
+}

--- a/ceph-proxy/terraform/offers.tf
+++ b/ceph-proxy/terraform/offers.tf
@@ -1,0 +1,10 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_offer" "offers" {
+  for_each = toset(var.offered_endpoints)
+
+  application_name = juju_application.ceph_proxy.name
+  endpoints        = [local.provides[each.value]]
+  model_uuid       = var.model_uuid
+}

--- a/ceph-proxy/terraform/outputs.tf
+++ b/ceph-proxy/terraform/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "application" {
+  description = "Object representing the deployed ceph-proxy application."
+  value       = juju_application.ceph_proxy
+}
+
+output "offers" {
+  description = "Map of exposed offer URLs keyed by endpoint key."
+  value       = local.offers
+}
+
+output "provides" {
+  description = "Map of provides endpoints keyed by relation alias."
+  value       = local.provides
+}
+
+output "requires" {
+  description = "Map of requires endpoints keyed by relation alias."
+  value       = local.requires
+}

--- a/ceph-proxy/terraform/providers.tf
+++ b/ceph-proxy/terraform/providers.tf
@@ -1,0 +1,5 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Provider requirements are declared in terraform.tf.
+# Intentionally no provider block: module consumers supply provider configuration.

--- a/ceph-proxy/terraform/terraform.tf
+++ b/ceph-proxy/terraform/terraform.tf
@@ -1,0 +1,13 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 1.0.0"
+    }
+  }
+}

--- a/ceph-proxy/terraform/variables.tf
+++ b/ceph-proxy/terraform/variables.tf
@@ -1,0 +1,70 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "ceph-proxy"
+}
+
+variable "base" {
+  description = "Operating system base used for deployment, e.g. ubuntu@24.04."
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
+variable "channel" {
+  description = "Channel of the charm to deploy."
+  type        = string
+  default     = "squid/stable"
+}
+
+variable "config" {
+  description = "Application config options for ceph-proxy."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = null
+}
+
+variable "model_uuid" {
+  description = "Reference to an existing Juju model UUID."
+  type        = string
+  nullable    = false
+}
+
+variable "offered_endpoints" {
+  description = "List of provided endpoint aliases to expose as Juju offers."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for alias in var.offered_endpoints :
+      contains(["client", "mds", "radosgw"], alias)
+    ])
+    error_message = "offered_endpoints must only contain ceph-proxy provides aliases."
+  }
+}
+
+variable "resources" {
+  description = "Resources to use with the application."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Revision number of the charm to deploy."
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units to deploy."
+  type        = number
+  default     = 1
+}

--- a/ceph-rbd-mirror/terraform/locals.tf
+++ b/ceph-rbd-mirror/terraform/locals.tf
@@ -1,0 +1,19 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+locals {
+  # Endpoint aliases are exported for composition by higher-level modules.
+  offers = {
+    for alias, offer in juju_offer.offers :
+    alias => offer.url
+  }
+
+  provides = {
+    nrpe_external_master = "nrpe-external-master"
+  }
+
+  requires = {
+    ceph_local  = "ceph-local"
+    ceph_remote = "ceph-remote"
+  }
+}

--- a/ceph-rbd-mirror/terraform/main.tf
+++ b/ceph-rbd-mirror/terraform/main.tf
@@ -1,0 +1,20 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_application" "ceph_rbd_mirror" {
+  # Juju provider v1 uses model UUIDs rather than model names for targeting.
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "ceph-rbd-mirror"
+    channel  = var.channel
+    revision = var.revision
+    base     = var.base
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  resources   = var.resources
+  units       = var.units
+}

--- a/ceph-rbd-mirror/terraform/offers.tf
+++ b/ceph-rbd-mirror/terraform/offers.tf
@@ -1,0 +1,10 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+resource "juju_offer" "offers" {
+  for_each = toset(var.offered_endpoints)
+
+  application_name = juju_application.ceph_rbd_mirror.name
+  endpoints        = [local.provides[each.value]]
+  model_uuid       = var.model_uuid
+}

--- a/ceph-rbd-mirror/terraform/outputs.tf
+++ b/ceph-rbd-mirror/terraform/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+output "application" {
+  description = "Object representing the deployed ceph-rbd-mirror application."
+  value       = juju_application.ceph_rbd_mirror
+}
+
+output "offers" {
+  description = "Map of exposed offer URLs keyed by endpoint key."
+  value       = local.offers
+}
+
+output "provides" {
+  description = "Map of provides endpoints keyed by relation alias."
+  value       = local.provides
+}
+
+output "requires" {
+  description = "Map of requires endpoints keyed by relation alias."
+  value       = local.requires
+}

--- a/ceph-rbd-mirror/terraform/providers.tf
+++ b/ceph-rbd-mirror/terraform/providers.tf
@@ -1,0 +1,5 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Provider requirements are declared in terraform.tf.
+# Intentionally no provider block: module consumers supply provider configuration.

--- a/ceph-rbd-mirror/terraform/terraform.tf
+++ b/ceph-rbd-mirror/terraform/terraform.tf
@@ -1,0 +1,13 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 1.0.0"
+    }
+  }
+}

--- a/ceph-rbd-mirror/terraform/variables.tf
+++ b/ceph-rbd-mirror/terraform/variables.tf
@@ -1,0 +1,70 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+variable "app_name" {
+  description = "Name of the application in the Juju model."
+  type        = string
+  default     = "ceph-rbd-mirror"
+}
+
+variable "base" {
+  description = "Operating system base used for deployment, e.g. ubuntu@24.04."
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
+variable "channel" {
+  description = "Channel of the charm to deploy."
+  type        = string
+  default     = "squid/stable"
+}
+
+variable "config" {
+  description = "Application config options for ceph-rbd-mirror."
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Juju constraints to apply for this application."
+  type        = string
+  default     = null
+}
+
+variable "model_uuid" {
+  description = "Reference to an existing Juju model UUID."
+  type        = string
+  nullable    = false
+}
+
+variable "offered_endpoints" {
+  description = "List of provided endpoint aliases to expose as Juju offers."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for alias in var.offered_endpoints :
+      contains(["nrpe_external_master"], alias)
+    ])
+    error_message = "offered_endpoints must only contain ceph-rbd-mirror provides aliases."
+  }
+}
+
+variable "resources" {
+  description = "Resources to use with the application."
+  type        = map(string)
+  default     = {}
+}
+
+variable "revision" {
+  description = "Revision number of the charm to deploy."
+  type        = number
+  default     = null
+}
+
+variable "units" {
+  description = "Number of units to deploy."
+  type        = number
+  default     = 1
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -4,8 +4,21 @@ This module deploys the `ceph-mon`, `ceph-osd`, and `ceph-radosgw` charms into a
 - `ceph-mon:osd` ↔ `ceph-osd:mon`
 - `ceph-mon:radosgw` ↔ `ceph-radosgw:mon`
 
+The remaining charms in this repo are available as opt-in additions. Each deploys
+only when its configuration object is non-null, keeping the default
+core topology unchanged. When enabled, the monitor-consuming charms are
+wired to `ceph-mon` automatically:
+- `ceph-fs:ceph-mds` ↔ `ceph-mon:mds`
+- `ceph-nfs:ceph-client` ↔ `ceph-mon:client`
+- `ceph-nvme:ceph-client` ↔ `ceph-mon:client`
+- `ceph-rbd-mirror:ceph-local` ↔ `ceph-mon:rbd-mirror`
+- `ceph-dashboard:dashboard` ↔ `ceph-mon:dashboard` (subordinate, colocated)
+
+`ceph-proxy` is a `ceph-mon` replacement that fronts an external cluster; it is
+deployed standalone and intentionally **not** wired to `ceph-mon`.
+
 Implementation model:
-- charm deployments are delegated to leaf modules (`../ceph-mon/terraform`, `../ceph-osd/terraform`, `../ceph-radosgw/terraform`)
+- charm deployments are delegated to leaf modules (`../ceph-mon/terraform`, `../ceph-osd/terraform`, `../ceph-radosgw/terraform`, and `../ceph-fs/terraform`, `../ceph-nfs/terraform`, `../ceph-nvme/terraform`, `../ceph-rbd-mirror/terraform`, `../ceph-dashboard/terraform`, `../ceph-proxy/terraform`)
 - this top-level module is responsible for cross-charm integrations and aggregated outputs
 
 It follows the CC008 component-module style with:
@@ -80,8 +93,14 @@ Exactly one non-empty model target must be provided: `model_uuid` or `model_name
 | `bootstrap_source` | `object` | DEPRECATED: External integration descriptor for `ceph-mon:bootstrap-source` (`kind = endpoint|offer`). This input will be removed in the Umbrella release. |
 | `secrets_storage` | `object` | External integration descriptor for `ceph-osd:secrets-storage` (`kind = endpoint|offer`). |
 | `expose_endpoints` | `list(string)` | List of `<charm>_<endpoint_alias>` keys from `provides` to publish as Juju offers. |
+| `ceph_fs` | `object` | Optional `ceph-fs` deployment. Set to a non-null object to deploy; wired to `ceph-mon:mds`. |
+| `ceph_nfs` | `object` | Optional `ceph-nfs` deployment. Set to a non-null object to deploy; wired to `ceph-mon:client`. `ceph-nfs` has no provides endpoints. |
+| `ceph_nvme` | `object` | Optional `ceph-nvme` deployment. Set to a non-null object to deploy; wired to `ceph-mon:client`. |
+| `ceph_rbd_mirror` | `object` | Optional `ceph-rbd-mirror` deployment. Set to a non-null object to deploy; its local cluster is wired to `ceph-mon:rbd-mirror`. |
+| `ceph_dashboard` | `object` | Optional `ceph-dashboard` deployment. Subordinate: colocated with `ceph-mon` via the `dashboard` relation; carries no units. |
+| `ceph_proxy` | `object` | Optional `ceph-proxy` deployment. A `ceph-mon` replacement fronting an external cluster; deployed standalone and not wired to `ceph-mon`. |
 
-Offer publication is enabled when either a charm's `offered_endpoints` list or this top-level `expose_endpoints` list includes a provided endpoint.
+Offer publication is enabled when either a charm's `offered_endpoints` list or this top-level `expose_endpoints` list includes a provided endpoint. An `expose_endpoints` entry for an opt-in charm is valid only when that charm's configuration object is non-null.
 
 > **Warning**: The `bootstrap_source` Terraform input maps to ceph-mon's
 > deprecated `bootstrap-source` relation and will be removed in the Umbrella
@@ -143,5 +162,38 @@ module "ceph_component" {
     base    = "ubuntu@24.04"
     units   = 1
   }
+}
+```
+
+## Example (core cluster + ceph-fs and ceph-dashboard)
+
+Opt-in charms are enabled by setting their object to a non-null value (an empty
+object `{}` deploys with defaults). They are wired to `ceph-mon` automatically:
+
+```hcl
+module "ceph_component" {
+  source = "../terraform"
+
+  model_uuid = "00000000-0000-0000-0000-000000000000"
+
+  ceph_mon = {
+    units = 3
+    config = {
+      "monitor-count"      = "3"
+      "expected-osd-count" = "3"
+    }
+  }
+
+  ceph_osd = {
+    units = 3
+    storage_directives = {
+      "osd-devices" = "1G,1"
+    }
+  }
+
+  # Deploy ceph-fs (wired to ceph-mon:mds) and the subordinate ceph-dashboard
+  # (colocated with ceph-mon via the dashboard relation).
+  ceph_fs        = {}
+  ceph_dashboard = {}
 }
 ```

--- a/terraform/applications.tf
+++ b/terraform/applications.tf
@@ -54,3 +54,118 @@ module "ceph_radosgw" {
 
   depends_on = [terraform_data.validate_model_target]
 }
+
+# The remaining charms are opt-in: each deploys only when its object input is
+# non-null, keeping the default MON+OSD+RADOSGW topology unchanged. Charms
+# that consume the monitor cluster are wired to ceph-mon in integrations.tf.
+
+module "ceph_fs" {
+  count  = var.ceph_fs == null ? 0 : 1
+  source = "../ceph-fs/terraform"
+
+  app_name          = var.ceph_fs.app_name
+  base              = var.ceph_fs.base
+  channel           = var.ceph_fs.channel
+  config            = var.ceph_fs.config
+  constraints       = var.ceph_fs.constraints
+  model_uuid        = local.resolved_model_uuid
+  offered_endpoints = local.ceph_fs_offered_endpoints
+  resources         = var.ceph_fs.resources
+  revision          = var.ceph_fs.revision
+  units             = var.ceph_fs.units
+
+  depends_on = [terraform_data.validate_model_target]
+}
+
+module "ceph_nfs" {
+  count  = var.ceph_nfs == null ? 0 : 1
+  source = "../ceph-nfs/terraform"
+
+  app_name          = var.ceph_nfs.app_name
+  base              = var.ceph_nfs.base
+  channel           = var.ceph_nfs.channel
+  config            = var.ceph_nfs.config
+  constraints       = var.ceph_nfs.constraints
+  model_uuid        = local.resolved_model_uuid
+  offered_endpoints = local.ceph_nfs_offered_endpoints
+  resources         = var.ceph_nfs.resources
+  revision          = var.ceph_nfs.revision
+  units             = var.ceph_nfs.units
+
+  depends_on = [terraform_data.validate_model_target]
+}
+
+module "ceph_nvme" {
+  count  = var.ceph_nvme == null ? 0 : 1
+  source = "../ceph-nvme/terraform"
+
+  app_name          = var.ceph_nvme.app_name
+  base              = var.ceph_nvme.base
+  channel           = var.ceph_nvme.channel
+  config            = var.ceph_nvme.config
+  constraints       = var.ceph_nvme.constraints
+  model_uuid        = local.resolved_model_uuid
+  offered_endpoints = local.ceph_nvme_offered_endpoints
+  resources         = var.ceph_nvme.resources
+  revision          = var.ceph_nvme.revision
+  units             = var.ceph_nvme.units
+
+  depends_on = [terraform_data.validate_model_target]
+}
+
+module "ceph_rbd_mirror" {
+  count  = var.ceph_rbd_mirror == null ? 0 : 1
+  source = "../ceph-rbd-mirror/terraform"
+
+  app_name          = var.ceph_rbd_mirror.app_name
+  base              = var.ceph_rbd_mirror.base
+  channel           = var.ceph_rbd_mirror.channel
+  config            = var.ceph_rbd_mirror.config
+  constraints       = var.ceph_rbd_mirror.constraints
+  model_uuid        = local.resolved_model_uuid
+  offered_endpoints = local.ceph_rbd_mirror_offered_endpoints
+  resources         = var.ceph_rbd_mirror.resources
+  revision          = var.ceph_rbd_mirror.revision
+  units             = var.ceph_rbd_mirror.units
+
+  depends_on = [terraform_data.validate_model_target]
+}
+
+# ceph-dashboard is a subordinate charm: it carries no units of its own and is
+# colocated with ceph-mon via the dashboard relation defined in integrations.tf.
+module "ceph_dashboard" {
+  count  = var.ceph_dashboard == null ? 0 : 1
+  source = "../ceph-dashboard/terraform"
+
+  app_name          = var.ceph_dashboard.app_name
+  base              = var.ceph_dashboard.base
+  channel           = var.ceph_dashboard.channel
+  config            = var.ceph_dashboard.config
+  constraints       = var.ceph_dashboard.constraints
+  model_uuid        = local.resolved_model_uuid
+  offered_endpoints = local.ceph_dashboard_offered_endpoints
+  resources         = var.ceph_dashboard.resources
+  revision          = var.ceph_dashboard.revision
+
+  depends_on = [terraform_data.validate_model_target]
+}
+
+# ceph-proxy is a ceph-mon replacement that fronts an external cluster; it is
+# deployed standalone and intentionally not wired to ceph-mon.
+module "ceph_proxy" {
+  count  = var.ceph_proxy == null ? 0 : 1
+  source = "../ceph-proxy/terraform"
+
+  app_name          = var.ceph_proxy.app_name
+  base              = var.ceph_proxy.base
+  channel           = var.ceph_proxy.channel
+  config            = var.ceph_proxy.config
+  constraints       = var.ceph_proxy.constraints
+  model_uuid        = local.resolved_model_uuid
+  offered_endpoints = local.ceph_proxy_offered_endpoints
+  resources         = var.ceph_proxy.resources
+  revision          = var.ceph_proxy.revision
+  units             = var.ceph_proxy.units
+
+  depends_on = [terraform_data.validate_model_target]
+}

--- a/terraform/integrations.tf
+++ b/terraform/integrations.tf
@@ -70,3 +70,87 @@ resource "juju_integration" "ceph_osd_secrets_storage" {
     offer_url = var.secrets_storage.kind == "offer" ? var.secrets_storage.url : null
   }
 }
+
+# Opt-in integrations wiring the additional charms to the monitor cluster.
+# Each is created only when the corresponding charm object is non-null.
+
+# ceph-fs consumes the ceph-mds endpoint provided by ceph-mon:mds.
+resource "juju_integration" "ceph_mon_to_ceph_fs" {
+  count      = var.ceph_fs == null ? 0 : 1
+  model_uuid = local.resolved_model_uuid
+
+  application {
+    endpoint = "mds"
+    name     = module.ceph_mon.application.name
+  }
+
+  application {
+    endpoint = "ceph-mds"
+    name     = module.ceph_fs[0].application.name
+  }
+}
+
+# ceph-nfs consumes the ceph-client endpoint provided by ceph-mon:client.
+resource "juju_integration" "ceph_mon_to_ceph_nfs" {
+  count      = var.ceph_nfs == null ? 0 : 1
+  model_uuid = local.resolved_model_uuid
+
+  application {
+    endpoint = "client"
+    name     = module.ceph_mon.application.name
+  }
+
+  application {
+    endpoint = "ceph-client"
+    name     = module.ceph_nfs[0].application.name
+  }
+}
+
+# ceph-nvme consumes the ceph-client endpoint provided by ceph-mon:client.
+resource "juju_integration" "ceph_mon_to_ceph_nvme" {
+  count      = var.ceph_nvme == null ? 0 : 1
+  model_uuid = local.resolved_model_uuid
+
+  application {
+    endpoint = "client"
+    name     = module.ceph_mon.application.name
+  }
+
+  application {
+    endpoint = "ceph-client"
+    name     = module.ceph_nvme[0].application.name
+  }
+}
+
+# ceph-rbd-mirror consumes the local cluster via ceph-mon:rbd-mirror.
+resource "juju_integration" "ceph_mon_to_ceph_rbd_mirror" {
+  count      = var.ceph_rbd_mirror == null ? 0 : 1
+  model_uuid = local.resolved_model_uuid
+
+  application {
+    endpoint = "rbd-mirror"
+    name     = module.ceph_mon.application.name
+  }
+
+  application {
+    endpoint = "ceph-local"
+    name     = module.ceph_rbd_mirror[0].application.name
+  }
+}
+
+# ceph-dashboard is a subordinate colocated with ceph-mon via the dashboard
+# relation (ceph-mon:dashboard <-> ceph-dashboard:dashboard).
+resource "juju_integration" "ceph_mon_to_ceph_dashboard" {
+  count      = var.ceph_dashboard == null ? 0 : 1
+  model_uuid = local.resolved_model_uuid
+
+  application {
+    endpoint = "dashboard"
+    name     = module.ceph_mon.application.name
+  }
+
+  application {
+    endpoint = "dashboard"
+    name     = module.ceph_dashboard[0].application.name
+  }
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -21,6 +21,42 @@ locals {
     if startswith(key, "ceph_radosgw_")
   ])
 
+  ceph_fs_expose_aliases = toset([
+    for key in var.expose_endpoints :
+    trimprefix(key, "ceph_fs_")
+    if startswith(key, "ceph_fs_")
+  ])
+
+  ceph_nfs_expose_aliases = toset([
+    for key in var.expose_endpoints :
+    trimprefix(key, "ceph_nfs_")
+    if startswith(key, "ceph_nfs_")
+  ])
+
+  ceph_nvme_expose_aliases = toset([
+    for key in var.expose_endpoints :
+    trimprefix(key, "ceph_nvme_")
+    if startswith(key, "ceph_nvme_")
+  ])
+
+  ceph_rbd_mirror_expose_aliases = toset([
+    for key in var.expose_endpoints :
+    trimprefix(key, "ceph_rbd_mirror_")
+    if startswith(key, "ceph_rbd_mirror_")
+  ])
+
+  ceph_dashboard_expose_aliases = toset([
+    for key in var.expose_endpoints :
+    trimprefix(key, "ceph_dashboard_")
+    if startswith(key, "ceph_dashboard_")
+  ])
+
+  ceph_proxy_expose_aliases = toset([
+    for key in var.expose_endpoints :
+    trimprefix(key, "ceph_proxy_")
+    if startswith(key, "ceph_proxy_")
+  ])
+
   ceph_mon_offered_endpoints = sort(tolist(setunion(
     toset(coalesce(var.ceph_mon.offered_endpoints, [])),
     local.ceph_mon_expose_aliases,
@@ -34,6 +70,36 @@ locals {
   ceph_radosgw_offered_endpoints = sort(tolist(setunion(
     toset(coalesce(var.ceph_radosgw.offered_endpoints, [])),
     local.ceph_radosgw_expose_aliases,
+  )))
+
+  ceph_fs_offered_endpoints = sort(tolist(setunion(
+    toset(var.ceph_fs == null ? [] : var.ceph_fs.offered_endpoints),
+    local.ceph_fs_expose_aliases,
+  )))
+
+  ceph_nfs_offered_endpoints = sort(tolist(setunion(
+    toset(var.ceph_nfs == null ? [] : var.ceph_nfs.offered_endpoints),
+    local.ceph_nfs_expose_aliases,
+  )))
+
+  ceph_nvme_offered_endpoints = sort(tolist(setunion(
+    toset(var.ceph_nvme == null ? [] : var.ceph_nvme.offered_endpoints),
+    local.ceph_nvme_expose_aliases,
+  )))
+
+  ceph_rbd_mirror_offered_endpoints = sort(tolist(setunion(
+    toset(var.ceph_rbd_mirror == null ? [] : var.ceph_rbd_mirror.offered_endpoints),
+    local.ceph_rbd_mirror_expose_aliases,
+  )))
+
+  ceph_dashboard_offered_endpoints = sort(tolist(setunion(
+    toset(var.ceph_dashboard == null ? [] : var.ceph_dashboard.offered_endpoints),
+    local.ceph_dashboard_expose_aliases,
+  )))
+
+  ceph_proxy_offered_endpoints = sort(tolist(setunion(
+    toset(var.ceph_proxy == null ? [] : var.ceph_proxy.offered_endpoints),
+    local.ceph_proxy_expose_aliases,
   )))
 
   # Keep a stable output contract: relation keys are exposed as
@@ -50,6 +116,30 @@ locals {
     {
       for alias, offer_url in module.ceph_radosgw.offers :
       "ceph_radosgw_${alias}" => offer_url
+    },
+    var.ceph_fs == null ? {} : {
+      for alias, offer_url in module.ceph_fs[0].offers :
+      "ceph_fs_${alias}" => offer_url
+    },
+    var.ceph_nfs == null ? {} : {
+      for alias, offer_url in module.ceph_nfs[0].offers :
+      "ceph_nfs_${alias}" => offer_url
+    },
+    var.ceph_nvme == null ? {} : {
+      for alias, offer_url in module.ceph_nvme[0].offers :
+      "ceph_nvme_${alias}" => offer_url
+    },
+    var.ceph_rbd_mirror == null ? {} : {
+      for alias, offer_url in module.ceph_rbd_mirror[0].offers :
+      "ceph_rbd_mirror_${alias}" => offer_url
+    },
+    var.ceph_dashboard == null ? {} : {
+      for alias, offer_url in module.ceph_dashboard[0].offers :
+      "ceph_dashboard_${alias}" => offer_url
+    },
+    var.ceph_proxy == null ? {} : {
+      for alias, offer_url in module.ceph_proxy[0].offers :
+      "ceph_proxy_${alias}" => offer_url
     },
   )
 
@@ -75,6 +165,48 @@ locals {
         name     = module.ceph_radosgw.application.name
       }
     },
+    var.ceph_fs == null ? {} : {
+      for alias, endpoint in module.ceph_fs[0].provides :
+      "ceph_fs_${alias}" => {
+        endpoint = endpoint
+        name     = module.ceph_fs[0].application.name
+      }
+    },
+    var.ceph_nfs == null ? {} : {
+      for alias, endpoint in module.ceph_nfs[0].provides :
+      "ceph_nfs_${alias}" => {
+        endpoint = endpoint
+        name     = module.ceph_nfs[0].application.name
+      }
+    },
+    var.ceph_nvme == null ? {} : {
+      for alias, endpoint in module.ceph_nvme[0].provides :
+      "ceph_nvme_${alias}" => {
+        endpoint = endpoint
+        name     = module.ceph_nvme[0].application.name
+      }
+    },
+    var.ceph_rbd_mirror == null ? {} : {
+      for alias, endpoint in module.ceph_rbd_mirror[0].provides :
+      "ceph_rbd_mirror_${alias}" => {
+        endpoint = endpoint
+        name     = module.ceph_rbd_mirror[0].application.name
+      }
+    },
+    var.ceph_dashboard == null ? {} : {
+      for alias, endpoint in module.ceph_dashboard[0].provides :
+      "ceph_dashboard_${alias}" => {
+        endpoint = endpoint
+        name     = module.ceph_dashboard[0].application.name
+      }
+    },
+    var.ceph_proxy == null ? {} : {
+      for alias, endpoint in module.ceph_proxy[0].provides :
+      "ceph_proxy_${alias}" => {
+        endpoint = endpoint
+        name     = module.ceph_proxy[0].application.name
+      }
+    },
   )
 
   requires = merge(
@@ -97,6 +229,48 @@ locals {
       "ceph_radosgw_${alias}" => {
         endpoint = endpoint
         name     = module.ceph_radosgw.application.name
+      }
+    },
+    var.ceph_fs == null ? {} : {
+      for alias, endpoint in module.ceph_fs[0].requires :
+      "ceph_fs_${alias}" => {
+        endpoint = endpoint
+        name     = module.ceph_fs[0].application.name
+      }
+    },
+    var.ceph_nfs == null ? {} : {
+      for alias, endpoint in module.ceph_nfs[0].requires :
+      "ceph_nfs_${alias}" => {
+        endpoint = endpoint
+        name     = module.ceph_nfs[0].application.name
+      }
+    },
+    var.ceph_nvme == null ? {} : {
+      for alias, endpoint in module.ceph_nvme[0].requires :
+      "ceph_nvme_${alias}" => {
+        endpoint = endpoint
+        name     = module.ceph_nvme[0].application.name
+      }
+    },
+    var.ceph_rbd_mirror == null ? {} : {
+      for alias, endpoint in module.ceph_rbd_mirror[0].requires :
+      "ceph_rbd_mirror_${alias}" => {
+        endpoint = endpoint
+        name     = module.ceph_rbd_mirror[0].application.name
+      }
+    },
+    var.ceph_dashboard == null ? {} : {
+      for alias, endpoint in module.ceph_dashboard[0].requires :
+      "ceph_dashboard_${alias}" => {
+        endpoint = endpoint
+        name     = module.ceph_dashboard[0].application.name
+      }
+    },
+    var.ceph_proxy == null ? {} : {
+      for alias, endpoint in module.ceph_proxy[0].requires :
+      "ceph_proxy_${alias}" => {
+        endpoint = endpoint
+        name     = module.ceph_proxy[0].application.name
       }
     },
   )

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,20 +3,36 @@
 
 output "components" {
   description = "List of objects representing the deployed component applications."
-  value = [
-    module.ceph_mon.application,
-    module.ceph_osd.application,
-    module.ceph_radosgw.application,
-  ]
+  value = concat(
+    [
+      module.ceph_mon.application,
+      module.ceph_osd.application,
+      module.ceph_radosgw.application,
+    ],
+    var.ceph_fs == null ? [] : [module.ceph_fs[0].application],
+    var.ceph_nfs == null ? [] : [module.ceph_nfs[0].application],
+    var.ceph_nvme == null ? [] : [module.ceph_nvme[0].application],
+    var.ceph_rbd_mirror == null ? [] : [module.ceph_rbd_mirror[0].application],
+    var.ceph_dashboard == null ? [] : [module.ceph_dashboard[0].application],
+    var.ceph_proxy == null ? [] : [module.ceph_proxy[0].application],
+  )
 }
 
 output "components_map" {
   description = "Map of deployed component applications keyed by component name."
-  value = {
-    ceph_mon     = module.ceph_mon.application
-    ceph_osd     = module.ceph_osd.application
-    ceph_radosgw = module.ceph_radosgw.application
-  }
+  value = merge(
+    {
+      ceph_mon     = module.ceph_mon.application
+      ceph_osd     = module.ceph_osd.application
+      ceph_radosgw = module.ceph_radosgw.application
+    },
+    var.ceph_fs == null ? {} : { ceph_fs = module.ceph_fs[0].application },
+    var.ceph_nfs == null ? {} : { ceph_nfs = module.ceph_nfs[0].application },
+    var.ceph_nvme == null ? {} : { ceph_nvme = module.ceph_nvme[0].application },
+    var.ceph_rbd_mirror == null ? {} : { ceph_rbd_mirror = module.ceph_rbd_mirror[0].application },
+    var.ceph_dashboard == null ? {} : { ceph_dashboard = module.ceph_dashboard[0].application },
+    var.ceph_proxy == null ? {} : { ceph_proxy = module.ceph_proxy[0].application },
+  )
 }
 
 output "offers" {

--- a/terraform/validation.tf
+++ b/terraform/validation.tf
@@ -1,0 +1,31 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+locals {
+  optional_charm_exposure_enabled = {
+    ceph_dashboard  = var.ceph_dashboard != null
+    ceph_fs         = var.ceph_fs != null
+    ceph_nvme       = var.ceph_nvme != null
+    ceph_proxy      = var.ceph_proxy != null
+    ceph_rbd_mirror = var.ceph_rbd_mirror != null
+  }
+
+  disabled_charm_exposures = flatten([
+    for charm, enabled in local.optional_charm_exposure_enabled : [
+      for key in var.expose_endpoints : key
+      if startswith(key, "${charm}_") && !enabled
+    ]
+  ])
+}
+
+resource "terraform_data" "validate_optional_charm_exposures" {
+  count = length(local.disabled_charm_exposures) == 0 ? 0 : 1
+  input = true
+
+  lifecycle {
+    precondition {
+      condition     = length(local.disabled_charm_exposures) == 0
+      error_message = "expose_endpoints cannot reference an optional charm unless that charm is enabled."
+    }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -135,6 +135,146 @@ variable "ceph_radosgw" {
   }
 }
 
+variable "ceph_fs" {
+  description = "Optional configuration object for ceph-fs deployment. Set to a non-null object to deploy; the charm is wired to ceph-mon:mds."
+  type = object({
+    app_name          = optional(string, "ceph-fs")
+    base              = optional(string, "ubuntu@24.04")
+    channel           = optional(string, "squid/stable")
+    config            = optional(map(string), {})
+    constraints       = optional(string, null)
+    offered_endpoints = optional(list(string), [])
+    resources         = optional(map(string), {})
+    revision          = optional(number)
+    units             = optional(number, 1)
+  })
+  default = null
+
+  validation {
+    condition = alltrue([
+      for alias in var.ceph_fs == null ? [] : var.ceph_fs.offered_endpoints :
+      contains(["cephfs_share", "filesystem"], alias)
+    ])
+    error_message = "ceph_fs.offered_endpoints must only contain ceph-fs provides aliases."
+  }
+}
+
+variable "ceph_nfs" {
+  description = "Optional configuration object for ceph-nfs deployment. Set to a non-null object to deploy; the charm is wired to ceph-mon:client. ceph-nfs has no provides endpoints."
+  type = object({
+    app_name          = optional(string, "ceph-nfs")
+    base              = optional(string, "ubuntu@24.04")
+    channel           = optional(string, "squid/stable")
+    config            = optional(map(string), {})
+    constraints       = optional(string, null)
+    offered_endpoints = optional(list(string), [])
+    resources         = optional(map(string), {})
+    revision          = optional(number)
+    units             = optional(number, 1)
+  })
+  default = null
+
+  validation {
+    condition     = var.ceph_nfs == null || length(var.ceph_nfs.offered_endpoints) == 0
+    error_message = "ceph_nfs has no provides endpoints to offer; offered_endpoints must be empty."
+  }
+}
+
+variable "ceph_nvme" {
+  description = "Optional configuration object for ceph-nvme deployment. Set to a non-null object to deploy; the charm is wired to ceph-mon:client."
+  type = object({
+    app_name          = optional(string, "ceph-nvme")
+    base              = optional(string, "ubuntu@24.04")
+    channel           = optional(string, "squid/stable")
+    config            = optional(map(string), {})
+    constraints       = optional(string, null)
+    offered_endpoints = optional(list(string), [])
+    resources         = optional(map(string), {})
+    revision          = optional(number)
+    units             = optional(number, 1)
+  })
+  default = null
+
+  validation {
+    condition = alltrue([
+      for alias in var.ceph_nvme == null ? [] : var.ceph_nvme.offered_endpoints :
+      contains(["admin_access"], alias)
+    ])
+    error_message = "ceph_nvme.offered_endpoints must only contain ceph-nvme provides aliases."
+  }
+}
+
+variable "ceph_rbd_mirror" {
+  description = "Optional configuration object for ceph-rbd-mirror deployment. Set to a non-null object to deploy; the local cluster is wired to ceph-mon:rbd-mirror."
+  type = object({
+    app_name          = optional(string, "ceph-rbd-mirror")
+    base              = optional(string, "ubuntu@24.04")
+    channel           = optional(string, "squid/stable")
+    config            = optional(map(string), {})
+    constraints       = optional(string, null)
+    offered_endpoints = optional(list(string), [])
+    resources         = optional(map(string), {})
+    revision          = optional(number)
+    units             = optional(number, 1)
+  })
+  default = null
+
+  validation {
+    condition = alltrue([
+      for alias in var.ceph_rbd_mirror == null ? [] : var.ceph_rbd_mirror.offered_endpoints :
+      contains(["nrpe_external_master"], alias)
+    ])
+    error_message = "ceph_rbd_mirror.offered_endpoints must only contain ceph-rbd-mirror provides aliases."
+  }
+}
+
+variable "ceph_dashboard" {
+  description = "Optional configuration object for ceph-dashboard deployment. ceph-dashboard is a subordinate charm colocated with ceph-mon via the dashboard relation; it carries no units of its own."
+  type = object({
+    app_name          = optional(string, "ceph-dashboard")
+    base              = optional(string, "ubuntu@24.04")
+    channel           = optional(string, "squid/stable")
+    config            = optional(map(string), {})
+    constraints       = optional(string, null)
+    offered_endpoints = optional(list(string), [])
+    resources         = optional(map(string), {})
+    revision          = optional(number)
+  })
+  default = null
+
+  validation {
+    condition = alltrue([
+      for alias in var.ceph_dashboard == null ? [] : var.ceph_dashboard.offered_endpoints :
+      contains(["grafana_dashboard"], alias)
+    ])
+    error_message = "ceph_dashboard.offered_endpoints must only contain ceph-dashboard provides aliases."
+  }
+}
+
+variable "ceph_proxy" {
+  description = "Optional configuration object for ceph-proxy deployment. Set to a non-null object to deploy. ceph-proxy is a ceph-mon replacement that fronts an external cluster; it is deployed standalone and not wired to ceph-mon."
+  type = object({
+    app_name          = optional(string, "ceph-proxy")
+    base              = optional(string, "ubuntu@24.04")
+    channel           = optional(string, "squid/stable")
+    config            = optional(map(string), {})
+    constraints       = optional(string, null)
+    offered_endpoints = optional(list(string), [])
+    resources         = optional(map(string), {})
+    revision          = optional(number)
+    units             = optional(number, 1)
+  })
+  default = null
+
+  validation {
+    condition = alltrue([
+      for alias in var.ceph_proxy == null ? [] : var.ceph_proxy.offered_endpoints :
+      contains(["client", "mds", "radosgw"], alias)
+    ])
+    error_message = "ceph_proxy.offered_endpoints must only contain ceph-proxy provides aliases."
+  }
+}
+
 variable "expose_endpoints" {
   description = "Optional list of provided endpoint keys to expose as offers, using the <charm>_<endpoint_alias> format."
   type        = list(string)
@@ -145,6 +285,9 @@ variable "expose_endpoints" {
       for key in var.expose_endpoints :
       contains(
         [
+          "ceph_dashboard_grafana_dashboard",
+          "ceph_fs_cephfs_share",
+          "ceph_fs_filesystem",
           "ceph_mon_admin",
           "ceph_mon_client",
           "ceph_mon_cos_agent",
@@ -156,7 +299,11 @@ variable "expose_endpoints" {
           "ceph_mon_prometheus",
           "ceph_mon_radosgw",
           "ceph_mon_rbd_mirror",
+          "ceph_nvme_admin_access",
           "ceph_osd_nrpe_external_master",
+          "ceph_proxy_client",
+          "ceph_proxy_mds",
+          "ceph_proxy_radosgw",
           "ceph_radosgw_gateway",
           "ceph_radosgw_master",
           "ceph_radosgw_nrpe_external_master",
@@ -164,6 +311,7 @@ variable "expose_endpoints" {
           "ceph_radosgw_primary",
           "ceph_radosgw_radosgw_user",
           "ceph_radosgw_s3",
+          "ceph_rbd_mirror_nrpe_external_master",
         ],
         key,
       )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,9 @@ import pytest
 # while still meeting Ceph charm minimum requirements.
 MODEL_CONSTRAINTS = (
     "virt-type=virtual-machine",
-    "mem=4G",
-    "root-disk=16G",
+    "cores=4",
+    "mem=8G",
+    "root-disk=40G",
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,14 +9,38 @@ import subprocess
 import jubilant
 import pytest
 
-# Baseline machine constraints keep integration runs predictable on CI runners
-# while still meeting Ceph charm minimum requirements.
-MODEL_CONSTRAINTS = (
+# Light constraints for the core (non-slow) tests. PR/main CI runs these on a
+# single self-hosted runner, so keep the per-machine footprint small; the
+# 3 MON + 3 OSD + RGW stack has historically run within these limits.
+MODEL_CONSTRAINTS_CORE = (
+    "virt-type=virtual-machine",
+    "mem=4G",
+    "root-disk=16G",
+)
+
+# Heavier constraints for slow deployment scenarios that add charms on top of
+# the core stack or run multi-site topologies (dashboard, fs, nfs, nvme, proxy,
+# rbd-mirror). Scheduled CI runs these on a longer-timeout job.
+MODEL_CONSTRAINTS_SLOW = (
     "virt-type=virtual-machine",
     "cores=4",
     "mem=8G",
     "root-disk=40G",
 )
+
+
+def _model_constraints(request: pytest.FixtureRequest) -> tuple[str, ...]:
+    """Return model constraints sized for the requesting module's test scope.
+
+    Modules marked ``slow`` (module- or class-level) get the heavier scenario
+    constraints; core tests get the light CI baseline. The ``juju`` fixture is
+    module-scoped, so the first selected item determines the shared model's
+    constraints -- slow plan-only tests that reuse a core module's model are
+    unaffected by the light baseline since they perform no deployment.
+    """
+    if request.node.get_closest_marker("slow"):
+        return MODEL_CONSTRAINTS_SLOW
+    return MODEL_CONSTRAINTS_CORE
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -45,7 +69,7 @@ def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo) -> None:
         item.session.shouldstop = "abort_on_fail marker triggered"
 
 
-def _set_model_constraints(model_name: str) -> None:
+def _set_model_constraints(model_name: str, constraints: tuple[str, ...]) -> None:
     """Set model constraints suitable for Ceph integration tests."""
     subprocess.run(
         [
@@ -53,7 +77,7 @@ def _set_model_constraints(model_name: str) -> None:
             "set-model-constraints",
             "-m",
             model_name,
-            *MODEL_CONSTRAINTS,
+            *constraints,
         ],
         check=True,
     )
@@ -68,7 +92,7 @@ def juju(request: pytest.FixtureRequest) -> Iterator[jubilant.Juju]:
 
         if not model.model:
             raise ValueError("Juju model name unavailable")
-        _set_model_constraints(model.model)
+        _set_model_constraints(model.model, _model_constraints(request))
 
         yield model
         if request.session.testsfailed:

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -97,7 +97,16 @@ def wait_for_apps_active(
         status = juju.status()
         if jubilant.all_active(status, *apps):
             return status
-        if jubilant.any_error(status):
+        target_error = any(
+            app_status.app_status.current == "error"
+            or any(
+                unit_status.workload_status.current == "error"
+                for unit_status in app_status.units.values()
+            )
+            for app in apps
+            if (app_status := status.apps.get(app)) is not None
+        )
+        if target_error or jubilant.any_error(status):
             raise AssertionError(f"Juju reported an error status: {status}")
         time.sleep(poll_interval)
 

--- a/tests/integration/terraform/README.md
+++ b/tests/integration/terraform/README.md
@@ -1,0 +1,42 @@
+# Terraform deployment smoke tests
+
+These tests deploy published Ceph charms from Charmhub through the Terraform
+modules in this repository. They validate Terraform planning, application and
+integration creation, module outputs, convergence, and a small charm-specific
+smoke operation. Full data-path, failover, upgrade, and lifecycle coverage
+remains in each charm's functional test suite.
+
+The suite uses one temporary Juju model per test module:
+
+- `test_terraform.py`: core MON, OSD, and RadosGW component plus plan-time wiring
+- `test_ceph_fs.py`: core component plus CephFS
+- `test_ceph_nfs.py`: core component plus CephFS and NFS
+- `test_ceph_dashboard.py`: core component plus dashboard with temporary TLS
+- `test_ceph_nvme.py`: core component plus a two-unit NVMe gateway
+- `test_ceph_rbd_mirror.py`: two complete Ceph sites with cross-site mirroring
+- `test_ceph_proxy.py`: two-phase source-cluster and proxy deployment
+
+Run the core CI subset with:
+
+```bash
+tox -e terraform-integration -- -m "not slow" tests/integration/terraform
+```
+
+Run the scheduled deployment scenarios with:
+
+```bash
+tox -e terraform-integration -- -m slow tests/integration/terraform
+```
+
+Run every Terraform test locally with `tox -e terraform-integration`.
+
+Run a single scenario with:
+
+```bash
+tox -e terraform-integration -- tests/integration/terraform/test_ceph_fs.py
+```
+
+Use `--keep-models` and/or `--keep-terraform-workspace` for local debugging.
+Proxy workspaces contain an ephemeral Ceph admin key and must not be published.
+The Juju Terraform provider deploys Charmhub revisions; it cannot deploy local
+`.charm` files.

--- a/tests/integration/terraform/conftest.py
+++ b/tests/integration/terraform/conftest.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Terraform-specific pytest fixtures."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+import logging
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+from typing import Any
+
+import jubilant
+import pytest
+
+from tests.integration.terraform.helpers import (
+    TerraformController,
+    terraform_environment,
+)
+
+logger = logging.getLogger(__name__)
+
+TerraformControllerFactory = Callable[
+    [str, dict[str, Any] | None, str], TerraformController
+]
+
+
+@pytest.fixture(scope="module")
+def terraform_controller_factory(
+    juju: jubilant.Juju,
+    request: pytest.FixtureRequest,
+) -> Iterator[TerraformControllerFactory]:
+    """Create initialized Terraform workspaces tied to the module's Juju model."""
+    model_name = juju.model
+    if not model_name:
+        raise ValueError("Juju model name unavailable")
+
+    controllers: list[TerraformController] = []
+    workspaces: list[Path] = []
+
+    def create(
+        main_tf: str,
+        tfvars: dict[str, Any] | None = None,
+        prefix: str = "ceph-terraform-it-",
+    ) -> TerraformController:
+        workspace = Path(tempfile.mkdtemp(prefix=prefix))
+        workspaces.append(workspace)
+        (workspace / "main.tf").write_text(main_tf)
+
+        controller = TerraformController(workspace, terraform_environment(model_name))
+        if tfvars is not None:
+            controller.write_tfvars(tfvars)
+        controller.init()
+        controllers.append(controller)
+        return controller
+
+    yield create
+
+    if request.session.testsfailed:
+        subprocess.run(["juju", "status", "-m", model_name, "--relations"], check=False)
+
+    keep_models = bool(request.config.getoption("--keep-models"))
+    keep_workspace = bool(request.config.getoption("--keep-terraform-workspace"))
+
+    if keep_models:
+        logger.info("Keeping model %s and Terraform resources for debugging", model_name)
+    else:
+        for controller in reversed(controllers):
+            controller.destroy()
+
+    if keep_models or keep_workspace:
+        for workspace in workspaces:
+            logger.info("Keeping Terraform workspace at %s", workspace)
+    else:
+        for workspace in workspaces:
+            shutil.rmtree(workspace, ignore_errors=True)

--- a/tests/integration/terraform/helpers.py
+++ b/tests/integration/terraform/helpers.py
@@ -1,0 +1,468 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Shared helpers for Terraform integration tests."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+import subprocess
+from typing import Any
+
+from tests import helpers
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = helpers.find_repo_root(Path(__file__).resolve())
+COMPONENT_MODULE_SOURCE = f"{REPO_ROOT}//terraform"
+
+TF_TIMEOUT_INIT = 10 * 60
+TF_TIMEOUT_PLAN = 15 * 60
+TF_TIMEOUT_SHOW = 5 * 60
+TF_TIMEOUT_APPLY = 90 * 60
+TF_TIMEOUT_DESTROY = 20 * 60
+TF_TIMEOUT_DESTROY_RETRY = 5 * 60
+
+
+def collect_plan_addresses(module: dict[str, Any], addresses: set[str]) -> None:
+    """Collect resource addresses recursively from a Terraform plan module."""
+    for resource in module.get("resources", []):
+        address = resource.get("address")
+        if isinstance(address, str):
+            addresses.add(address)
+
+    for child in module.get("child_modules", []):
+        if isinstance(child, dict):
+            collect_plan_addresses(child, addresses)
+
+
+def planned_resource_addresses(plan_json: dict[str, Any]) -> set[str]:
+    """Return every resource address in a Terraform JSON plan."""
+    addresses: set[str] = set()
+    planned_values = plan_json.get("planned_values", {})
+    root_module = planned_values.get("root_module", {})
+    if isinstance(root_module, dict):
+        collect_plan_addresses(root_module, addresses)
+    return addresses
+
+
+def planned_output_value(plan_json: dict[str, Any], output_name: str) -> Any:
+    """Return a planned output value from either supported JSON location."""
+    planned_values = plan_json.get("planned_values", {})
+    outputs = planned_values.get("outputs", {})
+    if isinstance(outputs, dict):
+        output = outputs.get(output_name, {})
+        if isinstance(output, dict) and "value" in output:
+            return output["value"]
+
+    output_changes = plan_json.get("output_changes", {})
+    if isinstance(output_changes, dict):
+        output = output_changes.get(output_name, {})
+        if isinstance(output, dict) and "after" in output:
+            return output["after"]
+
+    raise KeyError(f"Planned output {output_name!r} not found in terraform plan JSON")
+
+
+def render_workspace_template(template_name: str, **replacements: str) -> str:
+    """Render a checked-in HCL workspace template using literal tokens."""
+    template_path = Path(__file__).parent / "workspaces" / template_name
+    rendered = template_path.read_text()
+    for token, value in replacements.items():
+        rendered = rendered.replace(f"__{token}__", value)
+    if "__" in rendered:
+        raise ValueError(f"Unresolved token in Terraform template {template_name}")
+    return rendered
+
+
+def workspace_main(module_source: str = COMPONENT_MODULE_SOURCE) -> str:
+    """Render the standard component-module test workspace."""
+    # The source is a package root + subdir (``<repo>//terraform``), so nested
+    # leaf-module relative paths remain inside one Terraform module package.
+    return f'''
+terraform {{
+  required_version = ">= 1.6"
+
+  required_providers {{
+    juju = {{
+      source  = "juju/juju"
+      version = ">= 1.0.0"
+    }}
+  }}
+}}
+
+provider "juju" {{}}
+
+variable "model_name" {{
+  type    = string
+  default = null
+}}
+
+variable "model_uuid" {{
+  type    = string
+  default = null
+}}
+
+variable "charm_channel" {{
+  type    = string
+  default = null
+}}
+
+variable "juju_base" {{
+  type    = string
+  default = null
+}}
+
+variable "bootstrap_source" {{
+  type    = any
+  default = null
+}}
+
+variable "secrets_storage" {{
+  type    = any
+  default = null
+}}
+
+variable "expose_endpoints" {{
+  type    = list(string)
+  default = []
+}}
+
+variable "ceph_radosgw" {{
+  type    = any
+  default = {{}}
+}}
+
+variable "ceph_fs" {{
+  type    = any
+  default = null
+}}
+
+variable "ceph_nfs" {{
+  type    = any
+  default = null
+}}
+
+variable "ceph_nvme" {{
+  type    = any
+  default = null
+}}
+
+variable "ceph_rbd_mirror" {{
+  type    = any
+  default = null
+}}
+
+variable "ceph_dashboard" {{
+  type    = any
+  default = null
+}}
+
+variable "ceph_proxy" {{
+  type    = any
+  default = null
+}}
+
+module "ceph" {{
+  source = {json.dumps(str(module_source))}
+
+  model_name       = var.model_name
+  model_uuid       = var.model_uuid
+  bootstrap_source = var.bootstrap_source
+  secrets_storage  = var.secrets_storage
+  expose_endpoints = var.expose_endpoints
+
+  ceph_mon = merge({{
+    units = 3
+    config = {{
+      "expected-osd-count" = "3"
+      "monitor-count"      = "3"
+    }}
+    }}, var.charm_channel == null ? {{}} : {{
+    channel = var.charm_channel
+    }}, var.juju_base == null ? {{}} : {{
+    base = var.juju_base
+  }})
+
+  ceph_osd = merge({{
+    units = 3
+    storage_directives = {{
+      "osd-devices" = "10G,1"
+    }}
+    }}, var.charm_channel == null ? {{}} : {{
+    channel = var.charm_channel
+    }}, var.juju_base == null ? {{}} : {{
+    base = var.juju_base
+  }})
+
+  ceph_radosgw = merge(
+    var.ceph_radosgw,
+    var.charm_channel == null ? {{}} : {{ channel = var.charm_channel }},
+    var.juju_base == null ? {{}} : {{ base = var.juju_base }},
+  )
+
+  ceph_fs = var.ceph_fs == null ? null : merge(
+    var.ceph_fs,
+    var.charm_channel == null ? {{}} : {{ channel = var.charm_channel }},
+    var.juju_base == null ? {{}} : {{ base = var.juju_base }},
+  )
+  ceph_nfs = var.ceph_nfs == null ? null : merge(
+    var.ceph_nfs,
+    var.charm_channel == null ? {{}} : {{ channel = var.charm_channel }},
+    var.juju_base == null ? {{}} : {{ base = var.juju_base }},
+  )
+  ceph_nvme = var.ceph_nvme == null ? null : merge(
+    var.ceph_nvme,
+    var.charm_channel == null ? {{}} : {{ channel = var.charm_channel }},
+    var.juju_base == null ? {{}} : {{ base = var.juju_base }},
+  )
+  ceph_rbd_mirror = var.ceph_rbd_mirror == null ? null : merge(
+    var.ceph_rbd_mirror,
+    var.charm_channel == null ? {{}} : {{ channel = var.charm_channel }},
+    var.juju_base == null ? {{}} : {{ base = var.juju_base }},
+  )
+  ceph_dashboard = var.ceph_dashboard == null ? null : merge(
+    var.ceph_dashboard,
+    var.charm_channel == null ? {{}} : {{ channel = var.charm_channel }},
+    var.juju_base == null ? {{}} : {{ base = var.juju_base }},
+  )
+  ceph_proxy = var.ceph_proxy == null ? null : merge(
+    var.ceph_proxy,
+    var.charm_channel == null ? {{}} : {{ channel = var.charm_channel }},
+    var.juju_base == null ? {{}} : {{ base = var.juju_base }},
+  )
+}}
+
+output "components" {{
+  value = module.ceph.components
+}}
+
+output "components_map" {{
+  value = module.ceph.components_map
+}}
+
+output "offers" {{
+  value = module.ceph.offers
+}}
+
+output "provides" {{
+  value = module.ceph.provides
+}}
+
+output "requires" {{
+  value = module.ceph.requires
+}}
+'''
+
+
+class TerraformController:
+    """Convenience wrapper around Terraform CLI operations."""
+
+    def __init__(self, workspace: Path, env: dict[str, str]):
+        self._workspace = workspace
+        self._env = env
+        self._redactions: set[str] = set()
+
+    @property
+    def workspace(self) -> Path:
+        return self._workspace
+
+    def add_redaction(self, value: str) -> None:
+        """Redact a secret and its non-empty lines from Terraform output."""
+        self._redactions.update(line for line in value.splitlines() if line)
+
+    def _redact(self, value: str) -> str:
+        for secret in sorted(self._redactions, key=len, reverse=True):
+            value = value.replace(secret, "<redacted>")
+        return value
+
+    def _run(
+        self,
+        *args: str,
+        check: bool = True,
+        timeout: int | None = None,
+        log_output: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        command = ["terraform", *args]
+
+        try:
+            result = subprocess.run(
+                command,
+                cwd=self._workspace,
+                env=self._env,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raw_stdout = exc.stdout or ""
+            raw_stderr = exc.stderr or ""
+            stdout = self._redact(
+                raw_stdout.decode(errors="replace")
+                if isinstance(raw_stdout, bytes)
+                else raw_stdout
+            )
+            stderr = self._redact(
+                raw_stderr.decode(errors="replace")
+                if isinstance(raw_stderr, bytes)
+                else raw_stderr
+            )
+            if stdout:
+                logger.info(stdout)
+            if stderr:
+                logger.warning(stderr)
+            logger.warning(
+                "Terraform command timed out after %ss: %s",
+                timeout,
+                " ".join(command),
+            )
+            exc.stdout = stdout
+            exc.stderr = stderr
+            raise
+
+        result = subprocess.CompletedProcess(
+            args=result.args,
+            returncode=result.returncode,
+            stdout=self._redact(result.stdout),
+            stderr=self._redact(result.stderr),
+        )
+
+        if log_output and result.stdout:
+            logger.info(result.stdout)
+        if log_output and result.stderr:
+            logger.warning(result.stderr)
+        if check and result.returncode != 0:
+            raise subprocess.CalledProcessError(
+                returncode=result.returncode,
+                cmd=command,
+                output=result.stdout,
+                stderr=result.stderr,
+            )
+        return result
+
+    def write_tfvars(self, values: dict[str, Any]) -> None:
+        """Write scenario variables without exposing secrets in command lines."""
+        path = self._workspace / "terraform.auto.tfvars.json"
+        path.write_text(json.dumps(values, indent=2, sort_keys=True) + "\n")
+        path.chmod(0o600)
+
+    def init(self) -> None:
+        self._run("init", "-input=false", "-no-color", timeout=TF_TIMEOUT_INIT)
+
+    def plan(self, *, out: str = "tfplan", extra_args: list[str] | None = None) -> None:
+        args = ["plan", "-input=false", "-no-color", "-out", out]
+        if extra_args:
+            args.extend(extra_args)
+        self._run(*args, timeout=TF_TIMEOUT_PLAN)
+
+    def assert_no_changes(self) -> None:
+        """Assert that the applied Terraform workspace has converged."""
+        result = self._run(
+            "plan",
+            "-input=false",
+            "-no-color",
+            "-detailed-exitcode",
+            check=False,
+            timeout=TF_TIMEOUT_PLAN,
+        )
+        if result.returncode == 2:
+            raise AssertionError("Terraform reported changes after the smoke test")
+        if result.returncode != 0:
+            raise subprocess.CalledProcessError(
+                returncode=result.returncode,
+                cmd=result.args,
+                output=result.stdout,
+                stderr=result.stderr,
+            )
+
+    def show_plan(self, plan_file: str = "tfplan") -> None:
+        self._run("show", "-no-color", plan_file, timeout=TF_TIMEOUT_SHOW)
+
+    def show_plan_json(self, plan_file: str = "tfplan") -> dict[str, Any]:
+        result = self._run(
+            "show",
+            "-json",
+            plan_file,
+            timeout=TF_TIMEOUT_SHOW,
+            log_output=False,
+        )
+        return json.loads(result.stdout)
+
+    def apply(self, *, plan_file: str = "tfplan") -> None:
+        self.plan(out=plan_file)
+        self._run(
+            "apply",
+            "-input=false",
+            "-no-color",
+            "-auto-approve",
+            plan_file,
+            timeout=TF_TIMEOUT_APPLY,
+        )
+
+    def destroy(self) -> None:
+        try:
+            result = self._run(
+                "destroy",
+                "-input=false",
+                "-no-color",
+                "-auto-approve",
+                check=False,
+                timeout=TF_TIMEOUT_DESTROY,
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning("terraform destroy timed out")
+            return
+
+        if result.returncode == 0:
+            return
+
+        logger.warning("terraform destroy exited with %s; retrying once", result.returncode)
+
+        try:
+            retry_result = self._run(
+                "destroy",
+                "-input=false",
+                "-no-color",
+                "-auto-approve",
+                check=False,
+                timeout=TF_TIMEOUT_DESTROY_RETRY,
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning("terraform destroy retry timed out")
+            return
+
+        if retry_result.returncode != 0:
+            logger.warning("terraform destroy retry exited with %s", retry_result.returncode)
+
+    def state_list(self) -> set[str]:
+        result = self._run("state", "list", timeout=TF_TIMEOUT_SHOW)
+        return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+    def outputs(self) -> dict[str, Any]:
+        result = self._run("output", "-json", timeout=TF_TIMEOUT_SHOW)
+        return json.loads(result.stdout)
+
+
+def terraform_environment(model_name: str) -> dict[str, str]:
+    """Return the Terraform environment for an integration test model."""
+    env = os.environ.copy()
+    env["TF_IN_AUTOMATION"] = "1"
+    env["JUJU_MODEL"] = model_name
+    env["TF_VAR_model_name"] = model_name
+    if juju_base := env.get("JUJU_BASE"):
+        env.setdefault("TF_VAR_juju_base", juju_base)
+    return env
+
+
+def assert_component_names(controller: TerraformController, expected: set[str]) -> None:
+    """Assert both component outputs contain exactly the expected applications."""
+    outputs = controller.outputs()
+    components = outputs["components"]["value"]
+    assert {component["name"] for component in components} == expected
+
+    components_map = outputs["components_map"]["value"]
+    assert {component["name"] for component in components_map.values()} == expected

--- a/tests/integration/terraform/test_ceph_dashboard.py
+++ b/tests/integration/terraform/test_ceph_dashboard.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Terraform deployment smoke test for ceph-dashboard."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+import subprocess
+
+import jubilant
+import pytest
+
+from tests import helpers
+from tests.integration.terraform.helpers import (
+    TerraformController,
+    assert_component_names,
+    workspace_main,
+)
+
+pytestmark = pytest.mark.slow
+
+EXPECTED_APPS = {"ceph-mon", "ceph-osd", "ceph-radosgw", "ceph-dashboard"}
+DASHBOARD_USER = "terraform-smoke"
+
+
+def _generate_certificate(directory: Path) -> dict[str, str]:
+    key_path = directory / "dashboard.key"
+    cert_path = directory / "dashboard.crt"
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-nodes",
+            "-days",
+            "1",
+            "-subj",
+            "/CN=ceph-dashboard",
+            "-addext",
+            "subjectAltName=DNS:ceph-dashboard",
+            "-keyout",
+            str(key_path),
+            "-out",
+            str(cert_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    certificate = cert_path.read_bytes()
+    return {
+        "ssl_cert": base64.b64encode(certificate).decode(),
+        "ssl_key": base64.b64encode(key_path.read_bytes()).decode(),
+        "ssl_ca": base64.b64encode(certificate).decode(),
+        "public-hostname": "ceph-dashboard",
+    }
+
+
+@pytest.fixture(scope="module")
+def terraform_controller(
+    terraform_controller_factory,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> TerraformController:
+    tls_config = _generate_certificate(tmp_path_factory.mktemp("dashboard-tls"))
+    controller = terraform_controller_factory(
+        workspace_main(),
+        {"ceph_dashboard": {"config": tls_config}},
+        "ceph-terraform-dashboard-",
+    )
+    for key in ("ssl_cert", "ssl_key", "ssl_ca"):
+        controller.add_redaction(tls_config[key])
+    return controller
+
+
+@pytest.fixture(scope="module")
+def applied_stack(
+    terraform_controller: TerraformController,
+    juju: jubilant.Juju,
+) -> TerraformController:
+    terraform_controller.apply()
+    helpers.wait_for_apps_active(juju, *sorted(EXPECTED_APPS), timeout=60 * 60)
+    return terraform_controller
+
+
+def test_plan(terraform_controller: TerraformController) -> None:
+    terraform_controller.plan(out="ceph-dashboard.tfplan")
+    terraform_controller.show_plan("ceph-dashboard.tfplan")
+
+
+def test_deployment_and_outputs(
+    applied_stack: TerraformController,
+    juju: jubilant.Juju,
+) -> None:
+    status = juju.status()
+    assert helpers.relation_exists(
+        status, app="ceph-mon", endpoint="dashboard", related_app="ceph-dashboard"
+    )
+    assert helpers.relation_exists(
+        status, app="ceph-dashboard", endpoint="dashboard", related_app="ceph-mon"
+    )
+
+    mon = status.apps["ceph-mon"]
+    dashboard_units = sum(
+        subordinate.startswith("ceph-dashboard/")
+        for unit in mon.units.values()
+        for subordinate in unit.subordinates
+    )
+    assert dashboard_units == len(mon.units)
+
+    assert_component_names(applied_stack, EXPECTED_APPS)
+    assert "module.ceph.module.ceph_dashboard[0].juju_application.ceph_dashboard" in (
+        applied_stack.state_list()
+    )
+
+
+def test_ceph_dashboard_smoke(
+    applied_stack: TerraformController,
+    juju: jubilant.Juju,
+) -> None:
+    added = juju.run(
+        "ceph-dashboard/leader",
+        "add-user",
+        {"username": DASHBOARD_USER, "role": "administrator"},
+        wait=10 * 60,
+    )
+    added.raise_on_failure()
+    assert added.results.get("password")
+
+    deleted = juju.run(
+        "ceph-dashboard/leader",
+        "delete-user",
+        {"username": DASHBOARD_USER},
+        wait=5 * 60,
+    )
+    deleted.raise_on_failure()
+
+
+def test_no_terraform_drift(applied_stack: TerraformController) -> None:
+    applied_stack.assert_no_changes()

--- a/tests/integration/terraform/test_ceph_fs.py
+++ b/tests/integration/terraform/test_ceph_fs.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Terraform deployment smoke test for ceph-fs."""
+
+from __future__ import annotations
+
+import json
+
+import jubilant
+import pytest
+
+from tests import helpers
+from tests.integration.terraform.helpers import (
+    TerraformController,
+    assert_component_names,
+    workspace_main,
+)
+
+pytestmark = pytest.mark.slow
+
+EXPECTED_APPS = {"ceph-mon", "ceph-osd", "ceph-radosgw", "ceph-fs"}
+
+
+@pytest.fixture(scope="module")
+def terraform_controller(terraform_controller_factory) -> TerraformController:
+    return terraform_controller_factory(
+        workspace_main(),
+        {"ceph_fs": {}},
+        "ceph-terraform-fs-",
+    )
+
+
+@pytest.fixture(scope="module")
+def applied_stack(
+    terraform_controller: TerraformController,
+    juju: jubilant.Juju,
+) -> TerraformController:
+    terraform_controller.apply()
+    helpers.wait_for_apps_active(juju, *sorted(EXPECTED_APPS), timeout=60 * 60)
+    return terraform_controller
+
+
+def test_plan(terraform_controller: TerraformController) -> None:
+    terraform_controller.plan(out="ceph-fs.tfplan")
+    terraform_controller.show_plan("ceph-fs.tfplan")
+
+
+def test_deployment_and_outputs(
+    applied_stack: TerraformController,
+    juju: jubilant.Juju,
+) -> None:
+    status = juju.status()
+    assert helpers.relation_exists(
+        status, app="ceph-mon", endpoint="mds", related_app="ceph-fs"
+    )
+    assert helpers.relation_exists(
+        status, app="ceph-fs", endpoint="ceph-mds", related_app="ceph-mon"
+    )
+    assert_component_names(applied_stack, EXPECTED_APPS)
+    assert "module.ceph.module.ceph_fs[0].juju_application.ceph_fs" in (
+        applied_stack.state_list()
+    )
+
+
+def test_ceph_fs_smoke(applied_stack: TerraformController, juju: jubilant.Juju) -> None:
+    task = juju.exec("ceph fs ls --format=json", unit="ceph-mon/leader", wait=5 * 60)
+    task.raise_on_failure()
+    filesystems = json.loads(task.stdout)
+    assert filesystems, "ceph-fs did not create a filesystem"
+
+
+def test_no_terraform_drift(applied_stack: TerraformController) -> None:
+    applied_stack.assert_no_changes()

--- a/tests/integration/terraform/test_ceph_nfs.py
+++ b/tests/integration/terraform/test_ceph_nfs.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Terraform deployment smoke test for ceph-nfs."""
+
+from __future__ import annotations
+
+import jubilant
+import pytest
+
+from tests import helpers
+from tests.integration.terraform.helpers import (
+    TerraformController,
+    assert_component_names,
+    workspace_main,
+)
+
+pytestmark = pytest.mark.slow
+
+EXPECTED_APPS = {
+    "ceph-mon",
+    "ceph-osd",
+    "ceph-radosgw",
+    "ceph-fs",
+    "ceph-nfs",
+}
+
+
+@pytest.fixture(scope="module")
+def terraform_controller(terraform_controller_factory) -> TerraformController:
+    return terraform_controller_factory(
+        workspace_main(),
+        {
+            "ceph_fs": {},
+            "ceph_nfs": {"units": 1},
+        },
+        "ceph-terraform-nfs-",
+    )
+
+
+@pytest.fixture(scope="module")
+def applied_stack(
+    terraform_controller: TerraformController,
+    juju: jubilant.Juju,
+) -> TerraformController:
+    terraform_controller.apply()
+    helpers.wait_for_apps_active(juju, *sorted(EXPECTED_APPS), timeout=60 * 60)
+    return terraform_controller
+
+
+def test_plan(terraform_controller: TerraformController) -> None:
+    terraform_controller.plan(out="ceph-nfs.tfplan")
+    terraform_controller.show_plan("ceph-nfs.tfplan")
+
+
+def test_deployment_and_outputs(
+    applied_stack: TerraformController,
+    juju: jubilant.Juju,
+) -> None:
+    status = juju.status()
+    assert helpers.relation_exists(
+        status, app="ceph-mon", endpoint="client", related_app="ceph-nfs"
+    )
+    assert helpers.relation_exists(
+        status, app="ceph-nfs", endpoint="ceph-client", related_app="ceph-mon"
+    )
+    assert_component_names(applied_stack, EXPECTED_APPS)
+
+    state = applied_stack.state_list()
+    assert "module.ceph.module.ceph_fs[0].juju_application.ceph_fs" in state
+    assert "module.ceph.module.ceph_nfs[0].juju_application.ceph_nfs" in state
+
+
+def test_ceph_nfs_smoke(applied_stack: TerraformController, juju: jubilant.Juju) -> None:
+    service = juju.exec(
+        "systemctl is-active nfs-ganesha",
+        unit="ceph-nfs/leader",
+        wait=5 * 60,
+    )
+    service.raise_on_failure()
+    assert service.stdout.strip() == "active"
+
+    listed = juju.run("ceph-nfs/leader", "list-shares", wait=5 * 60)
+    listed.raise_on_failure()
+    assert "exports" in listed.results
+
+
+def test_no_terraform_drift(applied_stack: TerraformController) -> None:
+    applied_stack.assert_no_changes()

--- a/tests/integration/terraform/test_ceph_nvme.py
+++ b/tests/integration/terraform/test_ceph_nvme.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Terraform deployment smoke test for ceph-nvme."""
+
+from __future__ import annotations
+
+import json
+
+import jubilant
+import pytest
+
+from tests import helpers
+from tests.integration.terraform.helpers import (
+    TerraformController,
+    assert_component_names,
+    workspace_main,
+)
+
+pytestmark = pytest.mark.slow
+
+EXPECTED_APPS = {"ceph-mon", "ceph-osd", "ceph-radosgw", "ceph-nvme"}
+POOL_NAME = "terraform-nvme"
+IMAGE_NAME = "smoke-image"
+
+
+@pytest.fixture(scope="module")
+def terraform_controller(terraform_controller_factory) -> TerraformController:
+    return terraform_controller_factory(
+        workspace_main(),
+        {
+            "ceph_nvme": {
+                "units": 2,
+                "constraints": "cores=8 mem=16G root-disk=40G",
+                "config": {
+                    "nr-hugepages": "0",
+                    "cpuset": "4",
+                },
+            }
+        },
+        "ceph-terraform-nvme-",
+    )
+
+
+@pytest.fixture(scope="module")
+def applied_stack(
+    terraform_controller: TerraformController,
+    juju: jubilant.Juju,
+) -> TerraformController:
+    terraform_controller.apply()
+    helpers.wait_for_apps_active(juju, *sorted(EXPECTED_APPS), timeout=90 * 60)
+    return terraform_controller
+
+
+def test_plan(terraform_controller: TerraformController) -> None:
+    terraform_controller.plan(out="ceph-nvme.tfplan")
+    terraform_controller.show_plan("ceph-nvme.tfplan")
+
+
+def test_deployment_and_outputs(
+    applied_stack: TerraformController,
+    juju: jubilant.Juju,
+) -> None:
+    status = juju.status()
+    assert helpers.relation_exists(
+        status, app="ceph-mon", endpoint="client", related_app="ceph-nvme"
+    )
+    assert helpers.relation_exists(
+        status, app="ceph-nvme", endpoint="ceph-client", related_app="ceph-mon"
+    )
+    assert len(status.apps["ceph-nvme"].units) == 2
+    assert_component_names(applied_stack, EXPECTED_APPS)
+    assert "module.ceph.module.ceph_nvme[0].juju_application.ceph_nvme" in (
+        applied_stack.state_list()
+    )
+
+
+def test_ceph_nvme_smoke(
+    applied_stack: TerraformController,
+    juju: jubilant.Juju,
+) -> None:
+    created_pool = juju.run(
+        "ceph-mon/leader",
+        "create-pool",
+        {"name": POOL_NAME, "app-name": "rbd"},
+        wait=10 * 60,
+    )
+    created_pool.raise_on_failure()
+
+    endpoint_nqn: str | None = None
+    try:
+        created_image = juju.exec(
+            f"rbd create --size 64 {POOL_NAME}/{IMAGE_NAME}",
+            unit="ceph-mon/leader",
+            wait=5 * 60,
+        )
+        created_image.raise_on_failure()
+
+        endpoint = juju.run(
+            "ceph-nvme/leader",
+            "create-endpoint",
+            {"rbd-pool": POOL_NAME, "rbd-image": IMAGE_NAME, "units": "1"},
+            wait=15 * 60,
+        )
+        endpoint.raise_on_failure()
+        endpoint_nqn = endpoint.results.get("nqn")
+        assert endpoint_nqn
+
+        listed = juju.run("ceph-nvme/leader", "list-endpoints", wait=5 * 60)
+        listed.raise_on_failure()
+        assert endpoint_nqn in json.dumps(listed.results)
+    finally:
+        if endpoint_nqn:
+            deleted = juju.run(
+                "ceph-nvme/leader",
+                "delete-endpoint",
+                {"nqn": endpoint_nqn},
+                wait=10 * 60,
+            )
+            deleted.raise_on_failure()
+        deleted_pool = juju.run(
+            "ceph-mon/leader",
+            "delete-pool",
+            {"name": POOL_NAME},
+            wait=10 * 60,
+        )
+        deleted_pool.raise_on_failure()
+
+
+def test_no_terraform_drift(applied_stack: TerraformController) -> None:
+    applied_stack.assert_no_changes()

--- a/tests/integration/terraform/test_ceph_proxy.py
+++ b/tests/integration/terraform/test_ceph_proxy.py
@@ -1,0 +1,139 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Terraform deployment smoke test for ceph-proxy."""
+
+from __future__ import annotations
+
+import json
+
+import jubilant
+import pytest
+
+from tests import helpers
+from tests.integration.terraform.helpers import (
+    COMPONENT_MODULE_SOURCE,
+    REPO_ROOT,
+    TerraformController,
+    render_workspace_template,
+)
+
+pytestmark = pytest.mark.slow
+
+SOURCE_APPS = {"ceph-mon", "ceph-osd", "ceph-radosgw"}
+PROXY_APPS = {"ceph-proxy", "proxy-ceph-fs"}
+
+
+@pytest.fixture(scope="module")
+def terraform_controller(terraform_controller_factory) -> TerraformController:
+    workspace = render_workspace_template(
+        "proxy.tf.tmpl",
+        COMPONENT_MODULE_SOURCE=COMPONENT_MODULE_SOURCE,
+        CEPH_FS_MODULE_SOURCE=f"{REPO_ROOT}//ceph-fs/terraform",
+    )
+    return terraform_controller_factory(
+        workspace,
+        {"proxy_config": None},
+        "ceph-terraform-proxy-",
+    )
+
+
+@pytest.fixture(scope="module")
+def source_stack(
+    terraform_controller: TerraformController,
+    juju: jubilant.Juju,
+) -> TerraformController:
+    terraform_controller.apply(plan_file="source.tfplan")
+    helpers.wait_for_apps_active(juju, *sorted(SOURCE_APPS), timeout=60 * 60)
+    return terraform_controller
+
+
+@pytest.fixture(scope="module")
+def applied_stack(
+    source_stack: TerraformController,
+    juju: jubilant.Juju,
+) -> TerraformController:
+    fsid_task = juju.exec("ceph fsid", unit="ceph-mon/leader", wait=5 * 60)
+    fsid_task.raise_on_failure()
+    key_task = juju.exec(
+        "ceph auth get-key client.admin",
+        unit="ceph-mon/leader",
+        wait=5 * 60,
+    )
+    key_task.raise_on_failure()
+
+    status = juju.status()
+    monitor_hosts = " ".join(
+        unit.public_address
+        for unit in status.apps["ceph-mon"].units.values()
+        if unit.public_address
+    )
+    assert monitor_hosts, "Unable to determine ceph-mon addresses"
+
+    admin_key = key_task.stdout.strip()
+    source_stack.add_redaction(admin_key)
+    source_stack.write_tfvars(
+        {
+            "proxy_config": {
+                "fsid": fsid_task.stdout.strip(),
+                "admin-key": admin_key,
+                "auth-supported": "cephx",
+                "monitor-hosts": monitor_hosts,
+            }
+        }
+    )
+    source_stack.apply(plan_file="proxy.tfplan")
+    helpers.wait_for_apps_active(
+        juju,
+        *sorted(SOURCE_APPS | PROXY_APPS),
+        timeout=60 * 60,
+    )
+    return source_stack
+
+
+def test_initial_plan(terraform_controller: TerraformController) -> None:
+    terraform_controller.plan(out="ceph-proxy-source.tfplan")
+    terraform_controller.show_plan("ceph-proxy-source.tfplan")
+
+
+def test_proxy_deployment_and_relations(
+    applied_stack: TerraformController,
+    juju: jubilant.Juju,
+) -> None:
+    status = juju.status()
+    assert helpers.relation_exists(
+        status,
+        app="ceph-proxy",
+        endpoint="mds",
+        related_app="proxy-ceph-fs",
+    )
+    assert helpers.relation_exists(
+        status,
+        app="proxy-ceph-fs",
+        endpoint="ceph-mds",
+        related_app="ceph-proxy",
+    )
+    assert not any(
+        relation.related_app == "ceph-mon"
+        for relations in status.apps["ceph-proxy"].relations.values()
+        for relation in relations
+    )
+
+    state = applied_stack.state_list()
+    assert "module.source.module.ceph_proxy[0].juju_application.ceph_proxy" in state
+    assert "module.proxy_ceph_fs[0].juju_application.ceph_fs" in state
+    assert "juju_integration.proxy_to_ceph_fs[0]" in state
+
+
+def test_ceph_proxy_smoke(
+    applied_stack: TerraformController,
+    juju: jubilant.Juju,
+) -> None:
+    task = juju.exec("ceph fs ls --format=json", unit="ceph-mon/leader", wait=5 * 60)
+    task.raise_on_failure()
+    filesystems = json.loads(task.stdout)
+    assert filesystems, "ceph-fs did not provision a filesystem through ceph-proxy"
+
+
+def test_no_terraform_drift(applied_stack: TerraformController) -> None:
+    applied_stack.assert_no_changes()

--- a/tests/integration/terraform/test_ceph_rbd_mirror.py
+++ b/tests/integration/terraform/test_ceph_rbd_mirror.py
@@ -1,0 +1,159 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Terraform deployment smoke test for a two-site RBD mirror topology."""
+
+from __future__ import annotations
+
+import json
+
+import jubilant
+import pytest
+
+from tests import helpers
+from tests.integration.terraform.helpers import (
+    COMPONENT_MODULE_SOURCE,
+    TerraformController,
+    render_workspace_template,
+)
+
+pytestmark = pytest.mark.slow
+
+CORE_APPS = {
+    "ceph-mon-a",
+    "ceph-osd-a",
+    "ceph-radosgw-a",
+    "ceph-mon-b",
+    "ceph-osd-b",
+    "ceph-radosgw-b",
+}
+MIRROR_APPS = {"ceph-rbd-mirror-a", "ceph-rbd-mirror-b"}
+POOL_NAME = "terraform-mirror"
+
+
+def _mirrors_ready_for_pool_setup(status: jubilant.Status) -> bool:
+    for app_name in MIRROR_APPS:
+        app = status.apps.get(app_name)
+        if app is None or app.app_status.current not in {"active", "waiting"}:
+            return False
+        if not app.units or any(unit.juju_status.current != "idle" for unit in app.units.values()):
+            return False
+    return True
+
+
+@pytest.fixture(scope="module")
+def terraform_controller(terraform_controller_factory) -> TerraformController:
+    workspace = render_workspace_template(
+        "rbd-mirror.tf.tmpl",
+        COMPONENT_MODULE_SOURCE=COMPONENT_MODULE_SOURCE,
+    )
+    return terraform_controller_factory(
+        workspace,
+        prefix="ceph-terraform-rbd-mirror-",
+    )
+
+
+@pytest.fixture(scope="module")
+def applied_stack(
+    terraform_controller: TerraformController,
+    juju: jubilant.Juju,
+) -> TerraformController:
+    terraform_controller.apply()
+    helpers.wait_for_apps_active(juju, *sorted(CORE_APPS), timeout=90 * 60)
+    juju.wait(
+        _mirrors_ready_for_pool_setup,
+        error=lambda status: jubilant.any_error(status, *MIRROR_APPS),
+        timeout=30 * 60,
+        successes=3,
+    )
+    return terraform_controller
+
+
+def test_plan(terraform_controller: TerraformController) -> None:
+    terraform_controller.plan(out="ceph-rbd-mirror.tfplan")
+    terraform_controller.show_plan("ceph-rbd-mirror.tfplan")
+
+
+def test_two_site_relations(
+    applied_stack: TerraformController,
+    juju: jubilant.Juju,
+) -> None:
+    status = juju.status()
+    expected = (
+        ("ceph-mon-a", "rbd-mirror", "ceph-rbd-mirror-a"),
+        ("ceph-rbd-mirror-a", "ceph-local", "ceph-mon-a"),
+        ("ceph-mon-b", "rbd-mirror", "ceph-rbd-mirror-b"),
+        ("ceph-rbd-mirror-b", "ceph-local", "ceph-mon-b"),
+        ("ceph-mon-b", "rbd-mirror", "ceph-rbd-mirror-a"),
+        ("ceph-rbd-mirror-a", "ceph-remote", "ceph-mon-b"),
+        ("ceph-mon-a", "rbd-mirror", "ceph-rbd-mirror-b"),
+        ("ceph-rbd-mirror-b", "ceph-remote", "ceph-mon-a"),
+    )
+    for app, endpoint, related_app in expected:
+        assert helpers.relation_exists(
+            status,
+            app=app,
+            endpoint=endpoint,
+            related_app=related_app,
+        )
+
+    state = applied_stack.state_list()
+    assert "juju_integration.mirror_a_remote" in state
+    assert "juju_integration.mirror_b_remote" in state
+    assert (
+        "module.site_a.module.ceph_rbd_mirror[0].juju_application.ceph_rbd_mirror"
+        in state
+    )
+    assert (
+        "module.site_b.module.ceph_rbd_mirror[0].juju_application.ceph_rbd_mirror"
+        in state
+    )
+
+
+def test_ceph_rbd_mirror_smoke(
+    applied_stack: TerraformController,
+    juju: jubilant.Juju,
+) -> None:
+    for suffix in ("a", "b"):
+        pool = juju.run(
+            f"ceph-mon-{suffix}/leader",
+            "create-pool",
+            {"name": POOL_NAME, "app-name": "rbd"},
+            wait=10 * 60,
+        )
+        pool.raise_on_failure()
+
+    try:
+        for suffix in ("a", "b"):
+            refreshed = juju.run(
+                f"ceph-rbd-mirror-{suffix}/leader",
+                "refresh-pools",
+                wait=10 * 60,
+            )
+            refreshed.raise_on_failure()
+
+        helpers.wait_for_apps_active(juju, *sorted(MIRROR_APPS), timeout=30 * 60)
+
+        for suffix in ("a", "b"):
+            status = juju.run(
+                f"ceph-rbd-mirror-{suffix}/leader",
+                "status",
+                {"verbose": True, "format": "json", "pools": POOL_NAME},
+                wait=10 * 60,
+            )
+            status.raise_on_failure()
+            output = json.loads(status.results["output"])
+            assert POOL_NAME in output
+    finally:
+        for suffix in ("a", "b"):
+            deleted = juju.run(
+                f"ceph-mon-{suffix}/leader",
+                "delete-pool",
+                {"name": POOL_NAME},
+                wait=10 * 60,
+            )
+            deleted.raise_on_failure()
+
+
+def test_no_terraform_drift(applied_stack: TerraformController) -> None:
+    applied_stack.assert_no_changes()

--- a/tests/integration/terraform/test_configuration.py
+++ b/tests/integration/terraform/test_configuration.py
@@ -3,19 +3,33 @@
 
 """Tests for Terraform integration test configuration."""
 
-from tests.integration.terraform.test_terraform import (
-    _terraform_environment,
-    _workspace_main,
+import subprocess
+
+import pytest
+
+from tests.integration.terraform.helpers import (
+    TerraformController,
+    terraform_environment,
+    workspace_main,
 )
 
 
 def test_workspace_forwards_juju_base_to_all_ceph_applications() -> None:
     """The generated root module should override every Ceph application base."""
-    workspace = _workspace_main("./terraform")
+    workspace = workspace_main("./terraform")
 
     assert 'variable "juju_base"' in workspace
-    assert workspace.count("var.juju_base == null") == 3
-    assert workspace.count("base = var.juju_base") == 3
+    assert workspace.count("var.juju_base == null") == 9
+    assert workspace.count("base = var.juju_base") == 9
+
+
+def test_workspace_forwards_channel_to_all_ceph_applications() -> None:
+    """The generated root module should override every Ceph application channel."""
+    workspace = workspace_main("./terraform")
+
+    assert 'variable "charm_channel"' in workspace
+    assert workspace.count("var.charm_channel == null") == 9
+    assert workspace.count("channel = var.charm_channel") == 9
 
 
 def test_juju_base_environment_maps_to_terraform_variable(monkeypatch) -> None:
@@ -23,9 +37,26 @@ def test_juju_base_environment_maps_to_terraform_variable(monkeypatch) -> None:
     monkeypatch.setenv("JUJU_BASE", "ubuntu@26.04")
     monkeypatch.delenv("TF_VAR_juju_base", raising=False)
 
-    env = _terraform_environment("controller:model")
+    env = terraform_environment("controller:model")
 
     assert env["TF_VAR_juju_base"] == "ubuntu@26.04"
+
+
+def test_timeout_redaction_handles_byte_output(tmp_path, monkeypatch) -> None:
+    """Partial timeout output may be bytes even when subprocess text mode is enabled."""
+    controller = TerraformController(tmp_path, {})
+    controller.add_redaction("secret")
+
+    def timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(args[0], 1, output=b"secret", stderr=b"secret")
+
+    monkeypatch.setattr(subprocess, "run", timeout)
+
+    with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+        controller._run("plan", timeout=1)
+
+    assert exc_info.value.stdout == "<redacted>"
+    assert exc_info.value.stderr == "<redacted>"
 
 
 def test_explicit_terraform_juju_base_takes_precedence(monkeypatch) -> None:
@@ -33,6 +64,6 @@ def test_explicit_terraform_juju_base_takes_precedence(monkeypatch) -> None:
     monkeypatch.setenv("JUJU_BASE", "ubuntu@26.04")
     monkeypatch.setenv("TF_VAR_juju_base", "ubuntu@24.04")
 
-    env = _terraform_environment("controller:model")
+    env = terraform_environment("controller:model")
 
     assert env["TF_VAR_juju_base"] == "ubuntu@24.04"

--- a/tests/integration/terraform/test_terraform.py
+++ b/tests/integration/terraform/test_terraform.py
@@ -7,24 +7,22 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import shutil
 import subprocess
-import tempfile
 import time
-from pathlib import Path
 from typing import Any
 
 import jubilant
 import pytest
 
 from tests import helpers
+from tests.integration.terraform.helpers import (
+    COMPONENT_MODULE_SOURCE,
+    TerraformController,
+    planned_resource_addresses as _planned_resource_addresses,
+    workspace_main as _workspace_main,
+)
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.slow
-
-REPO_ROOT = helpers.find_repo_root(Path(__file__).resolve())
-COMPONENT_MODULE_SOURCE = f"{REPO_ROOT}//terraform"
 
 CORE_APPS = ("ceph-mon", "ceph-osd")
 RGW_APP = "ceph-radosgw"
@@ -45,13 +43,6 @@ RGW_REJECTED_MESSAGES = {
 
 RGW_ATTACH_TIMEOUT = 15 * 60
 POLL_INTERVAL_SECONDS = 10
-
-TF_TIMEOUT_INIT = 10 * 60
-TF_TIMEOUT_PLAN = 10 * 60
-TF_TIMEOUT_SHOW = 5 * 60
-TF_TIMEOUT_APPLY = 45 * 60
-TF_TIMEOUT_DESTROY = 8 * 60
-TF_TIMEOUT_DESTROY_RETRY = 3 * 60
 
 EXPECTED_STATE_RESOURCES = {
     "module.ceph.module.ceph_mon.juju_application.ceph_mon",
@@ -106,8 +97,58 @@ OFFER_EXPOSURE_CASES = (
 )
 
 EXPOSE_ENDPOINTS_VALIDATION_ERROR = "expose_endpoints entries must be valid"
+DISABLED_CHARM_EXPOSURE_ERROR = "expose_endpoints cannot reference an optional charm"
 MODEL_TARGET_VALIDATION_ERROR = "Exactly one model target must be provided"
 TEST_MODEL_UUID = "00000000-0000-0000-0000-000000000001"
+
+# Opt-in charm wiring cases for the additional leaf modules. Each tuple is
+# (var_name, expected_integration_address, expected_application_address).
+ADDITIONAL_CHARM_INTEGRATION_CASES = (
+    (
+        "ceph_fs",
+        "module.ceph.juju_integration.ceph_mon_to_ceph_fs[0]",
+        "module.ceph.module.ceph_fs[0].juju_application.ceph_fs",
+    ),
+    (
+        "ceph_nfs",
+        "module.ceph.juju_integration.ceph_mon_to_ceph_nfs[0]",
+        "module.ceph.module.ceph_nfs[0].juju_application.ceph_nfs",
+    ),
+    (
+        "ceph_nvme",
+        "module.ceph.juju_integration.ceph_mon_to_ceph_nvme[0]",
+        "module.ceph.module.ceph_nvme[0].juju_application.ceph_nvme",
+    ),
+    (
+        "ceph_rbd_mirror",
+        "module.ceph.juju_integration.ceph_mon_to_ceph_rbd_mirror[0]",
+        "module.ceph.module.ceph_rbd_mirror[0].juju_application.ceph_rbd_mirror",
+    ),
+    (
+        "ceph_dashboard",
+        "module.ceph.juju_integration.ceph_mon_to_ceph_dashboard[0]",
+        "module.ceph.module.ceph_dashboard[0].juju_application.ceph_dashboard",
+    ),
+)
+
+# Additional charm applications and their ceph-mon integrations must not be
+# planned unless the corresponding object input is non-null.
+ADDITIONAL_CHARM_DEFAULT_ABSENT = (
+    "module.ceph.module.ceph_fs[0].juju_application.ceph_fs",
+    "module.ceph.module.ceph_nfs[0].juju_application.ceph_nfs",
+    "module.ceph.module.ceph_nvme[0].juju_application.ceph_nvme",
+    "module.ceph.module.ceph_rbd_mirror[0].juju_application.ceph_rbd_mirror",
+    "module.ceph.module.ceph_dashboard[0].juju_application.ceph_dashboard",
+    "module.ceph.module.ceph_proxy[0].juju_application.ceph_proxy",
+    "module.ceph.juju_integration.ceph_mon_to_ceph_fs[0]",
+    "module.ceph.juju_integration.ceph_mon_to_ceph_nfs[0]",
+    "module.ceph.juju_integration.ceph_mon_to_ceph_nvme[0]",
+    "module.ceph.juju_integration.ceph_mon_to_ceph_rbd_mirror[0]",
+    "module.ceph.juju_integration.ceph_mon_to_ceph_dashboard[0]",
+)
+
+CEPH_PROXY_APP_ADDRESS = "module.ceph.module.ceph_proxy[0].juju_application.ceph_proxy"
+CEPH_FS_OFFER_ADDRESS = 'module.ceph.module.ceph_fs[0].juju_offer.offers["cephfs_share"]'
 
 
 def _radosgw_related_to_mon(status: jubilant.Status) -> bool:
@@ -149,12 +190,12 @@ def _status_diagnostics(status: jubilant.Status) -> str:
     return " | ".join(app_summaries)
 
 
-def _wait_for_core_apps_or_skip_storage_constraints(
+def _wait_for_core_apps(
     juju: jubilant.Juju,
     *apps: str,
     timeout: int = helpers.DEFAULT_TIMEOUT,
 ) -> jubilant.Status:
-    """Wait for core apps to become active, skipping known host storage constraints."""
+    """Wait for core apps to become active and fail on storage exhaustion."""
     deadline = time.time() + timeout
 
     while time.time() < deadline:
@@ -162,7 +203,7 @@ def _wait_for_core_apps_or_skip_storage_constraints(
         if jubilant.all_active(status, *apps):
             return status
         if helpers.has_storage_error(status, LOOP_DEVICE_ERROR):
-            pytest.skip("Runner has no free loop devices for ceph-osd storage directives")
+            raise AssertionError("Runner has no free loop devices for ceph-osd storage directives")
         if jubilant.any_error(status):
             raise AssertionError(f"Juju reported an error status: {_status_diagnostics(status)}")
         time.sleep(POLL_INTERVAL_SECONDS)
@@ -215,353 +256,24 @@ def _wait_for_radosgw_usable(
     )
 
 
-def _collect_plan_addresses(module: dict[str, Any], addresses: set[str]) -> None:
-    for resource in module.get("resources", []):
-        address = resource.get("address")
-        if isinstance(address, str):
-            addresses.add(address)
-
-    for child in module.get("child_modules", []):
-        if isinstance(child, dict):
-            _collect_plan_addresses(child, addresses)
-
-
-def _planned_resource_addresses(plan_json: dict[str, Any]) -> set[str]:
-    addresses: set[str] = set()
-    planned_values = plan_json.get("planned_values", {})
-    root_module = planned_values.get("root_module", {})
-    if isinstance(root_module, dict):
-        _collect_plan_addresses(root_module, addresses)
-    return addresses
-
-
-def _planned_output_value(plan_json: dict[str, Any], output_name: str) -> Any:
-    planned_values = plan_json.get("planned_values", {})
-    outputs = planned_values.get("outputs", {})
-    if isinstance(outputs, dict):
-        output = outputs.get(output_name, {})
-        if isinstance(output, dict) and "value" in output:
-            return output["value"]
-
-    output_changes = plan_json.get("output_changes", {})
-    if isinstance(output_changes, dict):
-        output = output_changes.get(output_name, {})
-        if isinstance(output, dict) and "after" in output:
-            return output["after"]
-
-    raise KeyError(f"Planned output {output_name!r} not found in terraform plan JSON")
-
-
-def _workspace_main(module_source: str) -> str:
-    # Keep test workspace minimal and self-contained so each module test run can
-    # pass optional relation descriptors via plain JSON `-var` arguments.
-    # The source is a package root + subdir (`<repo>//terraform`) so nested
-    # leaf-module relative paths remain inside the same Terraform module package.
-    return f'''
-terraform {{
-  required_version = ">= 1.6"
-
-  required_providers {{
-    juju = {{
-      source  = "juju/juju"
-      version = ">= 1.0.0"
-    }}
-  }}
-}}
-
-provider "juju" {{}}
-
-variable "model_name" {{
-  type    = string
-  default = null
-}}
-
-variable "model_uuid" {{
-  type    = string
-  default = null
-}}
-
-variable "charm_channel" {{
-  type    = string
-  default = null
-}}
-
-variable "juju_base" {{
-  type    = string
-  default = null
-}}
-
-variable "bootstrap_source" {{
-  type    = any
-  default = null
-}}
-
-variable "secrets_storage" {{
-  type    = any
-  default = null
-}}
-
-variable "expose_endpoints" {{
-  type    = list(string)
-  default = []
-}}
-
-variable "ceph_radosgw" {{
-  type    = any
-  default = {{}}
-}}
-
-module "ceph" {{
-  source = {json.dumps(str(module_source))}
-
-  model_name       = var.model_name
-  model_uuid       = var.model_uuid
-  bootstrap_source = var.bootstrap_source
-  secrets_storage  = var.secrets_storage
-  expose_endpoints = var.expose_endpoints
-
-  ceph_mon = merge({{
-    units = 3
-    config = {{
-      "expected-osd-count" = "3"
-      "monitor-count"      = "3"
-    }}
-  }}, var.charm_channel == null ? {{}} : {{
-    channel = var.charm_channel
-  }}, var.juju_base == null ? {{}} : {{
-    base = var.juju_base
-  }})
-
-  ceph_osd = merge({{
-    units = 3
-    storage_directives = {{
-      "osd-devices" = "1G,1"
-    }}
-  }}, var.charm_channel == null ? {{}} : {{
-    channel = var.charm_channel
-  }}, var.juju_base == null ? {{}} : {{
-    base = var.juju_base
-  }})
-
-  ceph_radosgw = merge(
-    var.ceph_radosgw,
-    var.charm_channel == null ? {{}} : {{
-      channel = var.charm_channel
-    }},
-    var.juju_base == null ? {{}} : {{
-      base = var.juju_base
-    }},
-  )
-}}
-
-output "components" {{
-  value = module.ceph.components
-}}
-
-output "components_map" {{
-  value = module.ceph.components_map
-}}
-
-output "offers" {{
-  value = module.ceph.offers
-}}
-
-output "provides" {{
-  value = module.ceph.provides
-}}
-
-output "requires" {{
-  value = module.ceph.requires
-}}
-'''
-
-
-class TerraformController:
-    """Convenience wrapper around Terraform CLI operations for this test suite."""
-
-    def __init__(self, workspace: Path, env: dict[str, str]):
-        self._workspace = workspace
-        self._env = env
-
-    @property
-    def workspace(self) -> Path:
-        return self._workspace
-
-    def _run(
-        self,
-        *args: str,
-        check: bool = True,
-        timeout: int | None = None,
-        log_output: bool = True,
-    ) -> subprocess.CompletedProcess[str]:
-        command = ["terraform", *args]
-
-        try:
-            result = subprocess.run(
-                command,
-                cwd=self._workspace,
-                env=self._env,
-                check=False,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-            )
-        except subprocess.TimeoutExpired as exc:
-            stdout = exc.stdout or ""
-            stderr = exc.stderr or ""
-            if stdout:
-                logger.info(stdout)
-            if stderr:
-                logger.warning(stderr)
-            logger.warning(
-                "Terraform command timed out after %ss: %s",
-                timeout,
-                " ".join(command),
-            )
-            raise
-
-        if log_output and result.stdout:
-            logger.info(result.stdout)
-        if log_output and result.stderr:
-            logger.warning(result.stderr)
-        if check and result.returncode != 0:
-            raise subprocess.CalledProcessError(
-                returncode=result.returncode,
-                cmd=command,
-                output=result.stdout,
-                stderr=result.stderr,
-            )
-        return result
-
-    def init(self) -> None:
-        self._run("init", "-input=false", "-no-color", timeout=TF_TIMEOUT_INIT)
-
-    def plan(self, *, out: str = "tfplan", extra_args: list[str] | None = None) -> None:
-        args = ["plan", "-input=false", "-no-color", "-out", out]
-        if extra_args:
-            args.extend(extra_args)
-        self._run(*args, timeout=TF_TIMEOUT_PLAN)
-
-    def show_plan(self, plan_file: str = "tfplan") -> None:
-        self._run("show", "-no-color", plan_file, timeout=TF_TIMEOUT_SHOW)
-
-    def show_plan_json(self, plan_file: str = "tfplan") -> dict[str, Any]:
-        result = self._run(
-            "show",
-            "-json",
-            plan_file,
-            timeout=TF_TIMEOUT_SHOW,
-            log_output=False,
-        )
-        return json.loads(result.stdout)
-
-    def apply(self) -> None:
-        self.plan(out="tfplan")
-        self._run(
-            "apply",
-            "-input=false",
-            "-no-color",
-            "-auto-approve",
-            "tfplan",
-            timeout=TF_TIMEOUT_APPLY,
-        )
-
-    def destroy(self) -> None:
-        try:
-            result = self._run(
-                "destroy",
-                "-input=false",
-                "-no-color",
-                "-auto-approve",
-                check=False,
-                timeout=TF_TIMEOUT_DESTROY,
-            )
-        except subprocess.TimeoutExpired:
-            logger.warning("terraform destroy timed out")
-            return
-
-        if result.returncode == 0:
-            return
-
-        logger.warning("terraform destroy exited with %s; retrying once", result.returncode)
-
-        try:
-            retry_result = self._run(
-                "destroy",
-                "-input=false",
-                "-no-color",
-                "-auto-approve",
-                check=False,
-                timeout=TF_TIMEOUT_DESTROY_RETRY,
-            )
-        except subprocess.TimeoutExpired:
-            logger.warning("terraform destroy retry timed out")
-            return
-
-        if retry_result.returncode != 0:
-            logger.warning("terraform destroy retry exited with %s", retry_result.returncode)
-
-    def state_list(self) -> set[str]:
-        result = self._run("state", "list", timeout=TF_TIMEOUT_SHOW)
-        return {line.strip() for line in result.stdout.splitlines() if line.strip()}
-
-    def outputs(self) -> dict[str, Any]:
-        result = self._run("output", "-json", timeout=TF_TIMEOUT_SHOW)
-        return json.loads(result.stdout)
-
-
-def _terraform_environment(model_name: str) -> dict[str, str]:
-    """Return the Terraform environment for an integration test model."""
-    env = os.environ.copy()
-    env["TF_IN_AUTOMATION"] = "1"
-    env["JUJU_MODEL"] = model_name
-    env["TF_VAR_model_name"] = model_name
-    if juju_base := env.get("JUJU_BASE"):
-        env.setdefault("TF_VAR_juju_base", juju_base)
-    return env
+@pytest.fixture(scope="module")
+def terraform_controller(terraform_controller_factory) -> TerraformController:
+    """Provision the default component workspace for the core-stack tests."""
+    return terraform_controller_factory(
+        _workspace_main(COMPONENT_MODULE_SOURCE),
+        prefix="ceph-terraform-core-",
+    )
 
 
 @pytest.fixture(scope="module")
-def terraform_controller(
-    juju: jubilant.Juju, request: pytest.FixtureRequest
-) -> TerraformController:
-    """Provision an isolated Terraform workspace tied to the temporary Juju model."""
-    model_name = juju.model
-    if not model_name:
-        raise ValueError("Juju model name unavailable")
-
-    workspace = Path(tempfile.mkdtemp(prefix="ceph-terraform-it-"))
-
-    (workspace / "main.tf").write_text(_workspace_main(COMPONENT_MODULE_SOURCE))
-
-    controller = TerraformController(workspace, _terraform_environment(model_name))
-    controller.init()
-
-    keep_models = bool(request.config.getoption("--keep-models"))
-    keep_workspace = bool(request.config.getoption("--keep-terraform-workspace"))
-
-    yield controller
-
-    if request.session.testsfailed:
-        subprocess.run(["juju", "status", "-m", model_name], check=False)
-
-    if keep_models:
-        logger.info("Keeping model %s and Terraform resources for debugging", model_name)
-    else:
-        controller.destroy()
-
-    if keep_models or keep_workspace:
-        logger.info("Keeping Terraform workspace at %s", workspace)
-    else:
-        shutil.rmtree(workspace, ignore_errors=True)
-
-
-@pytest.fixture(scope="module")
-def applied_stack(terraform_controller: TerraformController, juju: jubilant.Juju) -> jubilant.Status:
+def applied_stack(
+    terraform_controller: TerraformController,
+    juju: jubilant.Juju,
+) -> jubilant.Status:
     """Apply the default Terraform stack and wait for expected readiness."""
     terraform_controller.apply()
 
-    _wait_for_core_apps_or_skip_storage_constraints(juju, *CORE_APPS)
+    _wait_for_core_apps(juju, *CORE_APPS)
     return _wait_for_radosgw_usable(juju)
 
 
@@ -627,7 +339,7 @@ class TestTerraformModule:
 
         osd_storage_directives = components_map["ceph_osd"]["storage_directives"] or {}
         assert set(osd_storage_directives) == {"osd-devices"}
-        assert osd_storage_directives["osd-devices"] == "1G,1"
+        assert osd_storage_directives["osd-devices"] == "10G,1"
 
         provides = outputs["provides"]["value"]
         for key in ("ceph_mon_osd", "ceph_mon_radosgw", "ceph_radosgw_s3"):
@@ -743,3 +455,94 @@ class TestTerraformOptionalInputWiring:
 
         details = f"{exc_info.value.output or ''}\n{exc_info.value.stderr or ''}"
         assert MODEL_TARGET_VALIDATION_ERROR in details
+
+
+@pytest.mark.slow
+class TestAdditionalCharmWiring:
+    """Plan-time wiring for the opt-in ceph-fs/nfs/nvme/rbd-mirror/dashboard/proxy modules."""
+
+    def test_additional_charms_absent_by_default(
+        self,
+        terraform_controller: TerraformController,
+    ) -> None:
+        """Opt-in charms and their integrations must not be planned by default."""
+        terraform_controller.plan(out="default-no-additional.tfplan")
+        addresses = _planned_resource_addresses(
+            terraform_controller.show_plan_json("default-no-additional.tfplan")
+        )
+        for address in ADDITIONAL_CHARM_DEFAULT_ABSENT:
+            assert address not in addresses, f"{address} should not be planned by default"
+
+    @pytest.mark.parametrize(
+        "var_name,expected_integration,expected_app",
+        ADDITIONAL_CHARM_INTEGRATION_CASES,
+    )
+    def test_additional_charm_integration_plan_wiring(
+        self,
+        terraform_controller: TerraformController,
+        var_name: str,
+        expected_integration: str,
+        expected_app: str,
+    ) -> None:
+        """Enabling an opt-in charm should plan its app and ceph-mon integration."""
+        plan_file = f"additional-{var_name}.tfplan"
+        terraform_controller.plan(
+            out=plan_file,
+            extra_args=["-var", f"{var_name}={json.dumps({})}"],
+        )
+        addresses = _planned_resource_addresses(terraform_controller.show_plan_json(plan_file))
+        assert expected_app in addresses, f"{expected_app} not planned when {var_name} is set"
+        assert expected_integration in addresses, (
+            f"{expected_integration} not planned when {var_name} is set"
+        )
+
+    def test_expose_disabled_charm_fails_validation(
+        self,
+        terraform_controller: TerraformController,
+    ) -> None:
+        """An offer cannot be requested for an optional charm that is disabled."""
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            terraform_controller.plan(
+                out="invalid-disabled-charm-offer.tfplan",
+                extra_args=[
+                    "-var",
+                    f"expose_endpoints={json.dumps(['ceph_fs_cephfs_share'])}",
+                ],
+            )
+
+        details = f"{exc_info.value.output or ''}\n{exc_info.value.stderr or ''}"
+        assert DISABLED_CHARM_EXPOSURE_ERROR in details
+
+    def test_ceph_proxy_deploys_without_integration(
+        self,
+        terraform_controller: TerraformController,
+    ) -> None:
+        """ceph-proxy is a mon replacement and must not be wired to ceph-mon."""
+        plan_file = "additional-ceph_proxy.tfplan"
+        terraform_controller.plan(
+            out=plan_file,
+            extra_args=["-var", f"ceph_proxy={json.dumps({})}"],
+        )
+        addresses = _planned_resource_addresses(terraform_controller.show_plan_json(plan_file))
+        assert CEPH_PROXY_APP_ADDRESS in addresses
+        assert not any("ceph_mon_to_ceph_proxy" in addr for addr in addresses), (
+            "ceph-proxy must not be wired to ceph-mon"
+        )
+
+    def test_expose_ceph_fs_offer(
+        self,
+        terraform_controller: TerraformController,
+    ) -> None:
+        """Deploying ceph-fs and exposing cephfs_share should publish a Juju offer."""
+        plan_file = "additional-ceph-fs-offer.tfplan"
+        terraform_controller.plan(
+            out=plan_file,
+            extra_args=[
+                "-var",
+                f"ceph_fs={json.dumps({})}",
+                "-var",
+                f"expose_endpoints={json.dumps(['ceph_fs_cephfs_share'])}",
+            ],
+        )
+        addresses = _planned_resource_addresses(terraform_controller.show_plan_json(plan_file))
+        assert CEPH_FS_OFFER_ADDRESS in addresses

--- a/tests/integration/terraform/workspaces/proxy.tf.tmpl
+++ b/tests/integration/terraform/workspaces/proxy.tf.tmpl
@@ -1,0 +1,100 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 1.0.0"
+    }
+  }
+}
+
+provider "juju" {}
+
+variable "model_name" {
+  type = string
+}
+
+variable "charm_channel" {
+  type    = string
+  default = null
+}
+
+variable "juju_base" {
+  type    = string
+  default = null
+}
+
+variable "proxy_config" {
+  type    = map(string)
+  default = null
+}
+
+data "juju_model" "target" {
+  name  = var.model_name
+  owner = "admin"
+}
+
+locals {
+  charm_overrides = merge(
+    var.charm_channel == null ? {} : { channel = var.charm_channel },
+    var.juju_base == null ? {} : { base = var.juju_base },
+  )
+}
+
+module "source" {
+  source = "__COMPONENT_MODULE_SOURCE__"
+
+  model_uuid = data.juju_model.target.uuid
+
+  ceph_mon = merge({
+    units = 3
+    config = {
+      "expected-osd-count" = "3"
+      "monitor-count"      = "3"
+    }
+  }, local.charm_overrides)
+
+  ceph_osd = merge({
+    units = 3
+    storage_directives = {
+      "osd-devices" = "10G,1"
+    }
+  }, local.charm_overrides)
+
+  ceph_radosgw = local.charm_overrides
+
+  ceph_proxy = var.proxy_config == null ? null : merge({
+    config = var.proxy_config
+  }, local.charm_overrides)
+}
+
+module "proxy_ceph_fs" {
+  count  = var.proxy_config == null ? 0 : 1
+  source = "__CEPH_FS_MODULE_SOURCE__"
+
+  app_name   = "proxy-ceph-fs"
+  base       = coalesce(var.juju_base, "ubuntu@24.04")
+  channel    = coalesce(var.charm_channel, "squid/stable")
+  model_uuid = data.juju_model.target.uuid
+}
+
+resource "juju_integration" "proxy_to_ceph_fs" {
+  count      = var.proxy_config == null ? 0 : 1
+  model_uuid = data.juju_model.target.uuid
+
+  application {
+    name     = "ceph-proxy"
+    endpoint = "mds"
+  }
+
+  application {
+    name     = module.proxy_ceph_fs[0].application.name
+    endpoint = "ceph-mds"
+  }
+
+  depends_on = [module.source]
+}

--- a/tests/integration/terraform/workspaces/rbd-mirror.tf.tmpl
+++ b/tests/integration/terraform/workspaces/rbd-mirror.tf.tmpl
@@ -1,0 +1,143 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 1.0.0"
+    }
+  }
+}
+
+provider "juju" {}
+
+variable "model_name" {
+  type = string
+}
+
+variable "charm_channel" {
+  type    = string
+  default = null
+}
+
+variable "juju_base" {
+  type    = string
+  default = null
+}
+
+data "juju_model" "target" {
+  name  = var.model_name
+  owner = "admin"
+}
+
+locals {
+  charm_overrides = merge(
+    var.charm_channel == null ? {} : { channel = var.charm_channel },
+    var.juju_base == null ? {} : { base = var.juju_base },
+  )
+}
+
+module "site_a" {
+  source = "__COMPONENT_MODULE_SOURCE__"
+
+  model_uuid = data.juju_model.target.uuid
+
+  ceph_mon = merge({
+    app_name = "ceph-mon-a"
+    units    = 3
+    config = {
+      "expected-osd-count" = "3"
+      "monitor-count"      = "3"
+    }
+  }, local.charm_overrides)
+
+  ceph_osd = merge({
+    app_name = "ceph-osd-a"
+    units    = 3
+    storage_directives = {
+      "osd-devices" = "10G,1"
+    }
+  }, local.charm_overrides)
+
+  ceph_radosgw = merge({
+    app_name = "ceph-radosgw-a"
+  }, local.charm_overrides)
+
+  ceph_rbd_mirror = merge({
+    app_name = "ceph-rbd-mirror-a"
+  }, local.charm_overrides)
+}
+
+module "site_b" {
+  source = "__COMPONENT_MODULE_SOURCE__"
+
+  model_uuid = data.juju_model.target.uuid
+
+  ceph_mon = merge({
+    app_name = "ceph-mon-b"
+    units    = 3
+    config = {
+      "expected-osd-count" = "3"
+      "monitor-count"      = "3"
+    }
+  }, local.charm_overrides)
+
+  ceph_osd = merge({
+    app_name = "ceph-osd-b"
+    units    = 3
+    storage_directives = {
+      "osd-devices" = "10G,1"
+    }
+  }, local.charm_overrides)
+
+  ceph_radosgw = merge({
+    app_name = "ceph-radosgw-b"
+  }, local.charm_overrides)
+
+  ceph_rbd_mirror = merge({
+    app_name = "ceph-rbd-mirror-b"
+  }, local.charm_overrides)
+}
+
+resource "juju_integration" "mirror_a_remote" {
+  model_uuid = data.juju_model.target.uuid
+
+  application {
+    name     = "ceph-rbd-mirror-a"
+    endpoint = "ceph-remote"
+  }
+
+  application {
+    name     = "ceph-mon-b"
+    endpoint = "rbd-mirror"
+  }
+
+  depends_on = [module.site_a, module.site_b]
+}
+
+resource "juju_integration" "mirror_b_remote" {
+  model_uuid = data.juju_model.target.uuid
+
+  application {
+    name     = "ceph-rbd-mirror-b"
+    endpoint = "ceph-remote"
+  }
+
+  application {
+    name     = "ceph-mon-a"
+    endpoint = "rbd-mirror"
+  }
+
+  depends_on = [module.site_a, module.site_b]
+}
+
+output "site_a_components" {
+  value = module.site_a.components_map
+}
+
+output "site_b_components" {
+  value = module.site_b.components_map
+}

--- a/tox.ini
+++ b/tox.ini
@@ -26,4 +26,4 @@ deps =
     jubilant~=1.0
     pyyaml
 commands =
-    pytest -v --tb native --log-cli-level=INFO -s tests/integration/terraform {posargs}
+    pytest -v --tb native --log-cli-level=INFO -s {posargs:tests/integration/terraform}


### PR DESCRIPTION
Extends Terraform support beyond the core ceph-mon/ceph-osd/ceph-radosgw module to cover the remaining charms, plus integration test coverage for all of them.

Changes:

 - New per-charm Terraform modules for ceph-dashboard, ceph-fs, ceph-nfs, ceph-nvme, ceph-proxy, and ceph-rbd-mirror (each with main.tf, variables.tf, outputs.tf, locals.tf, offers.tf,  providers.tf, terraform.tf).
 - Top-level module gains applications.tf, integrations.tf, locals.tf, validation.tf, and expanded variables.tf/outputs.tf to compose and wire the new charms.
 - Integration tests: new test_ceph_*.py suites for each new charm, a shared helpers.py and conftest.py, workspace templates (workspaces/*.tf.tmpl), and a large refactor of test_terraform.py to share harness code.
 - CI: updates to plan-terraform.yml.
 - Docs: README updates under terraform/ and tests/integration/terraform/.
