### PR TITLE
fix: change default source

### DIFF
--- a/ceph-fs/src/config.yaml
+++ b/ceph-fs/src/config.yaml
@@ -5,7 +5,7 @@ options:
     description: Mon and OSD debug level. Max is 20.
   source:
     type: string
-    default: caracal
+    default: distro
     description: |
       Optional configuration to support use of additional sources such as:
       .

--- a/ceph-mon/config.yaml
+++ b/ceph-mon/config.yaml
@@ -10,7 +10,7 @@ options:
       If set to True, supporting services will log to syslog.
   source:
     type: string
-    default: caracal
+    default: distro
     description: |
       Optional configuration to support use of additional sources such as:
       .

--- a/ceph-nfs/config.yaml
+++ b/ceph-nfs/config.yaml
@@ -10,7 +10,7 @@
 options:
   source:
     type: string
-    default: caracal
+    default: distro
     description: |
       Optional configuration to support use of additional sources such as:
         - ppa:myteam/ppa

--- a/ceph-osd/config.yaml
+++ b/ceph-osd/config.yaml
@@ -5,7 +5,7 @@ options:
     description: OSD debug level. Max is 20.
   source:
     type: string
-    default: caracal
+    default: distro
     description: |
       Optional configuration to support use of additional sources such as:
       .

--- a/ceph-proxy/config.yaml
+++ b/ceph-proxy/config.yaml
@@ -10,7 +10,7 @@ options:
       Setting this to True will allow supporting services to log to syslog.
   source:
     type: string
-    default: caracal
+    default: distro
     description: |
       Repository from which to install. May be one of the following:
       distro (default), ppa:somecustom/ppa, a deb url sources entry,

--- a/ceph-radosgw/config.yaml
+++ b/ceph-radosgw/config.yaml
@@ -5,7 +5,7 @@ options:
     description: RadosGW debug level. Max is 20.
   source:
     type: string
-    default: caracal
+    default: distro
     description: |
       Optional repository from which to install. May be one of the following:
       distro (default), ppa:somecustom/ppa, a deb url sources entry,


### PR DESCRIPTION
tentacle is natively avail on 26.04, not caracal

