### PR TITLE
test: anchor terraform-integration test path so posargs append

### DIFF
--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -45,5 +45,4 @@ jobs:
       - name: Run Terraform core tests
         run: |
           tox -e terraform-integration -- \
-            -m "not slow" \
-            tests/integration/terraform
+            -m "not slow"

--- a/tox.ini
+++ b/tox.ini
@@ -26,4 +26,4 @@ deps =
     jubilant~=1.0
     pyyaml
 commands =
-    pytest -v --tb native --log-cli-level=INFO -s {posargs:tests/integration/terraform}
+    pytest -v --tb native --log-cli-level=INFO -s tests/integration/terraform {posargs}


### PR DESCRIPTION
PR #222 changed the terraform-integration tox command from `pytest ... tests/integration/terraform {posargs}` to `pytest ... {posargs:tests/integration/terraform}` to support the core/additional (slow) split via a pytest marker.

The `{posargs:default}` form only uses the default path when NO positional args are supplied. Any caller that passes flags (e.g. the ceph-qa pre-deployed matrix runs `-- --keep-models --keep-terraform-workspace`) replaces the default path entirely, so pytest falls back to collecting from rootdir and imports every charm's unit_tests/ -> 79 collection ImportErrors (No module named 'charmhelpers', 'charms_ceph', ...), exit 2, before any deployment.

Re-anchor the test path as a fixed prefix so posargs append instead of replace. The core/additional split is implemented by the `slow` marker, not the path, so it is fully preserved. Drop the now-redundant explicit path from plan-terraform.yml (it would otherwise be passed twice).

