### PR TITLE
[radosgw] Fix Apache SSL VirtualHost generation for multi-VIP environments

### DIFF
--- a/ceph-radosgw/hooks/charmhelpers/contrib/openstack/context.py
+++ b/ceph-radosgw/hooks/charmhelpers/contrib/openstack/context.py
@@ -99,6 +99,7 @@ from charmhelpers.contrib.openstack.neutron import (
 )
 from charmhelpers.contrib.openstack.ip import (
     resolve_address,
+    resolve_addresses,
     INTERNAL,
     ADMIN,
     PUBLIC,
@@ -111,9 +112,11 @@ from charmhelpers.contrib.network.ip import (
     get_ipv6_addr,
     get_netmask_for_address,
     format_ipv6_addr,
+    is_address_in_network,
     is_bridge_member,
     is_ipv6_disabled,
     get_relation_ip,
+    resolve_network_cidr,
 )
 from charmhelpers.contrib.openstack.utils import (
     config_flags_parser,
@@ -1191,31 +1194,102 @@ class ApacheSSLContext(OSContextGenerator):
              ...]
         """
         addresses = []
+        vips_config = config('vip')
+        vip_set = set(vips_config.split()) if vips_config else set()
+        fallback = local_address(unit_get_fallback="private-address")
+
         for net_type in [INTERNAL, ADMIN, PUBLIC]:
             net_config = config(ADDRESS_MAP[net_type]['config'])
+            binding = ADDRESS_MAP[net_type]['binding']
             # NOTE(jamespage): Fallback must always be private address
             #                  as this is used to bind services on the
             #                  local unit.
-            fallback = local_address(unit_get_fallback="private-address")
             if net_config:
                 addr = get_address_in_network(net_config,
                                               fallback)
             else:
                 try:
-                    addr = network_get_primary_address(
-                        ADDRESS_MAP[net_type]['binding']
-                    )
+                    addr = network_get_primary_address(binding)
                 except (NotImplementedError, NoNetworkBinding):
                     addr = fallback
 
-            endpoint = resolve_address(net_type)
-            addresses.append((addr, endpoint))
+            # If get_address_in_network picked up a Pacemaker-managed VIP
+            # (secondary address on the interface), fall back to the Juju
+            # binding primary address which is always the unit's own stable
+            # local IP.  HAProxy forwards to local IPs, not VIPs.
+            if addr in vip_set:
+                try:
+                    addr = network_get_primary_address(binding)
+                except (NotImplementedError, NoNetworkBinding):
+                    addr = fallback
 
-        # Log the set of addresses to have a trail log and capture if tuples
-        # change over time in the same unit (LP: #1952414).
-        sorted_addresses = sorted(set(addresses))
-        log('get_network_addresses: {}'.format(sorted_addresses))
-        return sorted_addresses
+            endpoint_addresses = resolve_addresses(net_type)
+            if endpoint_addresses:
+                for endpoint_address in endpoint_addresses:
+                    addresses.append((addr, endpoint_address))
+            else:
+                endpoint = resolve_address(net_type)
+                addresses.append((addr, endpoint))
+
+        # Ensure ALL configured VIPs have a VirtualHost entry even when
+        # their network is not associated with any endpoint type binding
+        # or os-*-network config.  This covers environments where the
+        # number of VIPs exceeds the number of endpoint types.
+        if vip_set and is_clustered():
+            covered_endpoints = {ep for _, ep in addresses}
+            for vip in sorted(vip_set - covered_endpoints):
+                bind_addr = None
+                # Check if VIP belongs to an explicitly configured network
+                for net_type in [INTERNAL, ADMIN, PUBLIC]:
+                    net_config = config(ADDRESS_MAP[net_type]['config'])
+                    if net_config and is_address_in_network(
+                            net_config, vip):
+                        bind_addr = get_address_in_network(
+                            net_config, fallback)
+                        if bind_addr in vip_set:
+                            try:
+                                bind_addr = network_get_primary_address(
+                                    ADDRESS_MAP[net_type]['binding'])
+                            except (NotImplementedError, NoNetworkBinding):
+                                bind_addr = fallback
+                        break
+                # Otherwise try each Juju binding to find a matching one
+                if not bind_addr:
+                    for net_type in [INTERNAL, ADMIN, PUBLIC]:
+                        try:
+                            candidate = network_get_primary_address(
+                                ADDRESS_MAP[net_type]['binding'])
+                            candidate_cidr = resolve_network_cidr(
+                                candidate)
+                            if is_address_in_network(
+                                    candidate_cidr, vip):
+                                bind_addr = candidate
+                                break
+                        except (NotImplementedError, NoNetworkBinding):
+                            continue
+                # Last resort: resolve the VIP's own network CIDR and
+                # find a local (non-VIP) address on that network.
+                if not bind_addr:
+                    try:
+                        vip_cidr = resolve_network_cidr(vip)
+                        candidate = get_address_in_network(
+                            vip_cidr, fallback)
+                        if candidate not in vip_set:
+                            bind_addr = candidate
+                    except Exception:
+                        pass
+                if not bind_addr:
+                    bind_addr = fallback
+                addresses.append((bind_addr, vip))
+
+        # Preserve insertion order for deterministic rendering while
+        # removing duplicates.
+        unique_addresses = list(dict.fromkeys(addresses))
+
+        # Log the set of addresses to have a trail log and capture if
+        # tuples change over time in the same unit (LP: #1952414).
+        log('get_network_addresses: {}'.format(unique_addresses))
+        return unique_addresses
 
     def __call__(self):
         if isinstance(self.external_ports, str):
@@ -1245,10 +1319,22 @@ class ApacheSSLContext(OSContextGenerator):
                     self.configure_cert(cn)
             else:
                 # Expect cert/key provided in config (currently assumed that ca
-                # uses ip for cn)
+                # uses ip for cn).  Configure certs for all resolved
+                # addresses and all configured VIPs so that every
+                # advertised address gets a certificate.
+                cns_done = set()
                 for net_type in (INTERNAL, ADMIN, PUBLIC):
-                    cn = resolve_address(endpoint_type=net_type)
-                    self.configure_cert(cn)
+                    for cn in resolve_addresses(endpoint_type=net_type):
+                        if cn not in cns_done:
+                            self.configure_cert(cn)
+                            cns_done.add(cn)
+                # Also cover VIPs not matched by any endpoint type.
+                vips_config = config('vip')
+                if vips_config:
+                    for cn in vips_config.split():
+                        if cn not in cns_done:
+                            self.configure_cert(cn)
+                            cns_done.add(cn)
 
         addresses = self.get_network_addresses()
         for address, endpoint in addresses:

--- a/ceph-radosgw/hooks/charmhelpers/contrib/openstack/ip.py
+++ b/ceph-radosgw/hooks/charmhelpers/contrib/openstack/ip.py
@@ -243,6 +243,61 @@ def resolve_address(endpoint_type=PUBLIC, override=True):
     return resolved_address
 
 
+def resolve_addresses(endpoint_type=PUBLIC, override=True):
+    """Return all resolved addresses for an endpoint type.
+
+    This behaves like ``resolve_address`` but, when clustered with multiple
+    configured VIPs, it returns all matching VIPs in configured order.
+
+    If no multi-address match can be made, it falls back to the single address
+    from ``resolve_address`` to preserve legacy behaviour.
+
+    :param endpoint_type: Network endpoint type
+    :param override: Accept hostname overrides or not
+    :returns: List of resolved addresses
+    :rtype: list
+    """
+    if override:
+        resolved_override = _get_address_override(endpoint_type)
+        if resolved_override:
+            return [resolved_override]
+
+    vips = config('vip')
+    if vips:
+        vips = vips.split()
+    else:
+        vips = []
+
+    net_type = ADDRESS_MAP[endpoint_type]['config']
+    net_addr = config(net_type)
+    binding = ADDRESS_MAP[endpoint_type]['binding']
+
+    if is_clustered() and vips:
+        matching_vips = []
+        if net_addr:
+            matching_vips = [
+                vip for vip in vips if is_address_in_network(net_addr, vip)
+            ]
+        else:
+            try:
+                bound_cidr = resolve_network_cidr(
+                    network_get_primary_address(binding)
+                )
+                matching_vips = [
+                    vip for vip in vips
+                    if is_address_in_network(bound_cidr, vip)
+                ]
+            except (NotImplementedError, NoNetworkBinding):
+                # Fallback to legacy behaviour when network binding info
+                # is unavailable.
+                matching_vips = vips[:1]
+
+        if matching_vips:
+            return matching_vips
+
+    return [resolve_address(endpoint_type=endpoint_type, override=override)]
+
+
 def get_vip_in_network(network):
     matching_vip = None
     vips = config('vip')

--- a/ceph-radosgw/unit_tests/test_openstack_ip_context.py
+++ b/ceph-radosgw/unit_tests/test_openstack_ip_context.py
@@ -1,0 +1,289 @@
+# Copyright 2026 Canonical Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+import unittest
+
+from unittest.mock import patch
+
+import charmhelpers.contrib.openstack.context as os_context
+import charmhelpers.contrib.openstack.ip as os_ip
+
+
+class ResolveAddressesTests(unittest.TestCase):
+
+    @patch('charmhelpers.contrib.openstack.ip.is_address_in_network')
+    @patch('charmhelpers.contrib.openstack.ip.config')
+    @patch('charmhelpers.contrib.openstack.ip.is_clustered')
+    def test_resolve_addresses_returns_all_matching_vips(
+            self, is_clustered, config, is_address_in_network):
+        is_clustered.return_value = True
+
+        def _config_side_effect(key):
+            if key == 'vip':
+                return '10.0.0.10 10.0.0.11 10.1.0.10'
+            if key == 'os-public-network':
+                return '10.0.0.0/24'
+            if key == 'os-public-hostname':
+                return None
+            return None
+
+        config.side_effect = _config_side_effect
+        is_address_in_network.side_effect = (
+            lambda network, address: address.startswith('10.0.0.')
+        )
+
+        addresses = os_ip.resolve_addresses(endpoint_type=os_ip.PUBLIC,
+                                            override=True)
+
+        self.assertEqual(['10.0.0.10', '10.0.0.11'], addresses)
+
+    @patch('charmhelpers.contrib.openstack.ip.resolve_address')
+    @patch('charmhelpers.contrib.openstack.ip.is_address_in_network')
+    @patch('charmhelpers.contrib.openstack.ip.config')
+    @patch('charmhelpers.contrib.openstack.ip.is_clustered')
+    def test_resolve_addresses_falls_back_to_resolve_address(
+            self, is_clustered, config,
+            is_address_in_network, resolve_address):
+        is_clustered.return_value = True
+
+        def _config_side_effect(key):
+            if key == 'vip':
+                return '10.0.0.10 10.0.0.11'
+            if key == 'os-public-network':
+                return '172.16.0.0/24'
+            if key == 'os-public-hostname':
+                return None
+            return None
+
+        config.side_effect = _config_side_effect
+        is_address_in_network.return_value = False
+        resolve_address.return_value = '192.168.122.10'
+
+        addresses = os_ip.resolve_addresses(endpoint_type=os_ip.PUBLIC,
+                                            override=True)
+
+        self.assertEqual(['192.168.122.10'], addresses)
+
+
+class ApacheSSLContextAddressTests(unittest.TestCase):
+
+    @patch('charmhelpers.contrib.openstack.context.log')
+    @patch('charmhelpers.contrib.openstack.context.resolve_addresses')
+    @patch('charmhelpers.contrib.openstack.context.resolve_address')
+    @patch('charmhelpers.contrib.openstack.context'
+           '.network_get_primary_address')
+    @patch('charmhelpers.contrib.openstack.context.local_address')
+    @patch('charmhelpers.contrib.openstack.context.config')
+    def test_get_network_addresses_includes_all_resolved_addresses(
+            self, config, local_address, network_get_primary_address,
+            resolve_address, resolve_addresses, _log):
+        ctxt = os_context.ApacheSSLContext()
+
+        def _config_side_effect(key):
+            if key in ('os-internal-network', 'os-admin-network',
+                       'os-public-network'):
+                return None
+            return None
+
+        config.side_effect = _config_side_effect
+        local_address.return_value = '192.168.122.10'
+        network_get_primary_address.side_effect = (
+            lambda binding: {
+                'internal': '192.168.10.10',
+                'admin': '192.168.20.10',
+                'public': '192.168.30.10',
+            }[binding]
+        )
+        resolve_address.side_effect = (
+            lambda endpoint_type: {
+                os_ip.INTERNAL: 'int.example.com',
+                os_ip.ADMIN: 'admin.example.com',
+                os_ip.PUBLIC: 'public.example.com',
+            }[endpoint_type]
+        )
+        resolve_addresses.side_effect = (
+            lambda endpoint_type: {
+                os_ip.INTERNAL: ['10.0.1.10'],
+                os_ip.ADMIN: ['10.0.2.10', '10.0.2.10', '10.0.2.11'],
+                os_ip.PUBLIC: ['10.0.3.10'],
+            }[endpoint_type]
+        )
+
+        addresses = ctxt.get_network_addresses()
+
+        self.assertEqual([
+            ('192.168.10.10', '10.0.1.10'),
+            ('192.168.20.10', '10.0.2.10'),
+            ('192.168.20.10', '10.0.2.11'),
+            ('192.168.30.10', '10.0.3.10'),
+        ], addresses)
+
+    @patch('charmhelpers.contrib.openstack.context.log')
+    @patch('charmhelpers.contrib.openstack.context.is_clustered')
+    @patch('charmhelpers.contrib.openstack.context.resolve_addresses')
+    @patch('charmhelpers.contrib.openstack.context.resolve_address')
+    @patch('charmhelpers.contrib.openstack.context'
+           '.network_get_primary_address')
+    @patch('charmhelpers.contrib.openstack.context.get_address_in_network')
+    @patch('charmhelpers.contrib.openstack.context.local_address')
+    @patch('charmhelpers.contrib.openstack.context.config')
+    def test_get_network_addresses_replaces_vip_bind_address(
+            self, config, local_address, get_address_in_network,
+            network_get_primary_address, resolve_address,
+            resolve_addresses, is_clustered, _log):
+        """If get_address_in_network returns a VIP, fall back to binding."""
+        ctxt = os_context.ApacheSSLContext()
+        is_clustered.return_value = True
+
+        def _config_side_effect(key):
+            if key == 'vip':
+                return '10.1.33.1 10.1.41.1 192.168.99.51'
+            if key == 'os-internal-network':
+                return '10.1.32.0/21'
+            if key == 'os-admin-network':
+                return '10.1.40.0/21'
+            if key == 'os-public-network':
+                return '192.168.96.0/21'
+            return None
+
+        config.side_effect = _config_side_effect
+        local_address.return_value = '10.1.32.111'
+
+        # Simulate get_address_in_network returning VIPs (as can happen
+        # when Pacemaker assigns them as secondary addresses).
+        def _get_addr_in_network(net, fallback):
+            return {
+                '10.1.32.0/21': '10.1.33.1',   # VIP
+                '10.1.40.0/21': '10.1.41.1',   # VIP
+                '192.168.96.0/21': '192.168.99.206',  # local
+            }.get(net, fallback)
+
+        get_address_in_network.side_effect = _get_addr_in_network
+
+        # network_get_primary_address returns the correct local IPs
+        network_get_primary_address.side_effect = (
+            lambda binding: {
+                'internal': '10.1.32.111',
+                'admin': '10.1.40.116',
+                'public': '192.168.99.206',
+            }[binding]
+        )
+        resolve_addresses.side_effect = (
+            lambda endpoint_type: {
+                os_ip.INTERNAL: ['10.1.33.1'],
+                os_ip.ADMIN: ['10.1.41.1'],
+                os_ip.PUBLIC: ['192.168.99.51'],
+            }[endpoint_type]
+        )
+
+        addresses = ctxt.get_network_addresses()
+
+        # VIPs must NOT appear as bind addresses
+        for addr, _endpoint in addresses:
+            self.assertNotIn(addr, {'10.1.33.1', '10.1.41.1',
+                                    '192.168.99.51'})
+        # All 3 VIPs must appear as endpoints
+        endpoints = [ep for _, ep in addresses]
+        self.assertIn('10.1.33.1', endpoints)
+        self.assertIn('10.1.41.1', endpoints)
+        self.assertIn('192.168.99.51', endpoints)
+
+    @patch('charmhelpers.contrib.openstack.context.log')
+    @patch('charmhelpers.contrib.openstack.context.is_clustered')
+    @patch('charmhelpers.contrib.openstack.context.resolve_network_cidr')
+    @patch('charmhelpers.contrib.openstack.context.is_address_in_network')
+    @patch('charmhelpers.contrib.openstack.context.resolve_addresses')
+    @patch('charmhelpers.contrib.openstack.context.resolve_address')
+    @patch('charmhelpers.contrib.openstack.context'
+           '.network_get_primary_address')
+    @patch('charmhelpers.contrib.openstack.context.get_address_in_network')
+    @patch('charmhelpers.contrib.openstack.context.local_address')
+    @patch('charmhelpers.contrib.openstack.context.config')
+    def test_get_network_addresses_covers_uncovered_vips(
+            self, config, local_address, get_address_in_network,
+            network_get_primary_address,
+            resolve_address, resolve_addresses, is_address_in_network,
+            resolve_network_cidr, is_clustered, _log):
+        """VIPs not matched by any endpoint type must still get entries."""
+        ctxt = os_context.ApacheSSLContext()
+        is_clustered.return_value = True
+
+        def _config_side_effect(key):
+            if key == 'vip':
+                return '10.1.33.1 10.1.41.1 192.168.99.51'
+            if key == 'os-internal-network':
+                return '10.1.32.0/21'
+            if key == 'os-admin-network':
+                return '10.1.40.0/21'
+            # PUBLIC not configured, falls back to binding which
+            # resolves to same network as INTERNAL.
+            if key == 'os-public-network':
+                return None
+            return None
+
+        config.side_effect = _config_side_effect
+        local_address.return_value = '10.1.32.111'
+
+        # get_address_in_network simulates Pacemaker VIPs on eth2/eth3
+        # and the correct local address on eth0's network.
+        def _get_address_in_network(net, fallback):
+            return {
+                '10.1.32.0/21': '10.1.33.1',       # VIP (secondary)
+                '10.1.40.0/21': '10.1.41.1',       # VIP (secondary)
+                '192.168.96.0/21': '192.168.99.206',  # local primary
+            }.get(net, fallback)
+
+        get_address_in_network.side_effect = _get_address_in_network
+
+        # Public binding returns same address as internal (LP#2161718)
+        network_get_primary_address.side_effect = (
+            lambda binding: {
+                'internal': '10.1.32.111',
+                'admin': '10.1.40.116',
+                'public': '10.1.32.111',  # same as internal
+            }[binding]
+        )
+        # resolve_addresses for PUBLIC returns same VIP as INTERNAL
+        # since the binding is in the same network
+        resolve_addresses.side_effect = (
+            lambda endpoint_type: {
+                os_ip.INTERNAL: ['10.1.33.1'],
+                os_ip.ADMIN: ['10.1.41.1'],
+                os_ip.PUBLIC: ['10.1.33.1'],  # same as INTERNAL
+            }[endpoint_type]
+        )
+
+        # is_address_in_network for the reconciliation phase
+        def _is_address_in_network(network, address):
+            import ipaddress
+            return ipaddress.ip_address(address) in \
+                ipaddress.ip_network(network)
+
+        is_address_in_network.side_effect = _is_address_in_network
+
+        # resolve_network_cidr maps all relevant addresses including VIP
+        resolve_network_cidr.side_effect = (
+            lambda addr: {
+                '10.1.32.111': '10.1.32.0/21',
+                '10.1.40.116': '10.1.40.0/21',
+                '192.168.99.51': '192.168.96.0/21',
+            }[addr]
+        )
+
+        addresses = ctxt.get_network_addresses()
+
+        # The uncovered VIP 192.168.99.51 must appear as an endpoint
+        # bound to the LOCAL address on that network (not the VIP)
+        endpoints = [ep for _, ep in addresses]
+        self.assertIn('192.168.99.51', endpoints)
+        self.assertIn('10.1.33.1', endpoints)
+        self.assertIn('10.1.41.1', endpoints)
+        # Verify the bind address for the uncovered VIP is the local IP
+        vip_tuple = [(a, e) for a, e in addresses if e == '192.168.99.51']
+        self.assertEqual(vip_tuple, [('192.168.99.206', '192.168.99.51')])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When 3+ VIPs are configured, Apache only generated VirtualHost entries for VIPs matching the 3 endpoint types (internal/admin/public), leaving uncovered VIPs without SSL termination. Additionally, get_address_in_network could return a Pacemaker-managed VIP instead of the unit's local IP, causing HAProxy backend mismatches.

Now all matching VIPs per endpoint type are returned nad detects & replaces VIP bind addresses with local IPs so that every configured VIP gets a VirtualHost entry.

Fixes #2161718.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes LP#216718.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

> **_NOTE:_** All functional changes should accompany corresponding tests (unit tests, functional tests etc).

Please describe the addition/modification of tests done to verify this change. Please also list any relevant details for your test configuration.

Test covering various scenarios is included as part of this change.

## Contributor's Checklist

Please check that you have:

- [x] considered and tested upgrade scenarios from a previous stable version.
- [x] self-reviewed the code in this PR.
- [x] added code comments, particularly in hard-to-understand areas.
- [ ] updated the user documentation with corresponding changes.
- [x] added tests to verify effectiveness of this change.
