### PR TITLE
[DNM] test: cover RGW admin datalog shard info

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -155,6 +155,15 @@ jobs:
             newgrp lxd
             lxd init --minimal
           fi
+          # Disable IPv6 on the default bridge. Otherwise model machines get
+          # an IPv6 address alongside their IPv4 one, and zaza's vault setup
+          # reaches keystone over HTTPS by machine address; the vault-issued
+          # certificate only covers the IPv4 SAN, so when the IPv6 address is
+          # picked, cert validation fails and the whole run aborts in the
+          # configure step before any test runs. Runs unconditionally because
+          # a self-hosted runner may already have lxdbr0 up with IPv6 enabled,
+          # skipping the init above.
+          sudo lxc network set lxdbr0 ipv6.address none
 
       - name: Install and configure tests
         run: |

--- a/ceph-dashboard/tests/bundles/noble-caracal.yaml
+++ b/ceph-dashboard/tests/bundles/noble-caracal.yaml
@@ -2,7 +2,7 @@ local_overlay_enabled: False
 series: noble
 variables:
   openstack-origin: &openstack-origin distro
-  source: &source distro
+  source: &source ppa:johnramsden/noble-caracal-ceph-tentacle
 
 machines:
   '0':
@@ -19,7 +19,7 @@ applications:
     storage:
       osd-devices: 'loop,10G'
     options:
-      source: *openstack-origin
+      source: *source
       osd-devices: '/dev/test-non-existent'
     channel: latest/edge
     to:
@@ -30,7 +30,7 @@ applications:
     charm: ch:ceph-mon
     num_units: 3
     options:
-      source: *openstack-origin
+      source: *source
       monitor-count: '3'
     channel: latest/edge
   vault:

--- a/ceph-fs/src/tests/bundles/noble-caracal.yaml
+++ b/ceph-fs/src/tests/bundles/noble-caracal.yaml
@@ -1,5 +1,6 @@
 variables:
   openstack-origin: &openstack-origin distro
+  source: &source ppa:johnramsden/noble-caracal-ceph-tentacle
 
 series: &series noble
 
@@ -20,7 +21,7 @@ applications:
     channel: latest/edge
     num_units: 1
     options:
-      source: *openstack-origin
+      source: *source
       pool-type: erasure-coded
       ec-profile-k: 4
       ec-profile-m: 2
@@ -34,7 +35,7 @@ applications:
       osd-devices: 'loop,10G'
     options:
       osd-devices: '/dev/test-non-existent'
-      source: *openstack-origin
+      source: *source
     channel: latest/edge
     to:
       - '0'
@@ -46,7 +47,7 @@ applications:
     num_units: 3
     options:
       monitor-count: '3'
-      source: *openstack-origin
+      source: *source
     channel: latest/edge
     to:
       - '3'

--- a/ceph-mon/tests/bundles/noble-caracal.yaml
+++ b/ceph-mon/tests/bundles/noble-caracal.yaml
@@ -22,6 +22,7 @@ applications:
     num_units: 3
     options:
       monitor-count: 3
+      source: ppa:johnramsden/noble-caracal-ceph-tentacle
     to:
       - '0'
       - '1'
@@ -33,6 +34,8 @@ applications:
     channel: latest/edge
     storage:
       osd-devices: 'loop,8G'
+    options:
+      source: ppa:johnramsden/noble-caracal-ceph-tentacle
     to:
       - '3'
       - '4'

--- a/ceph-mon/tests/target.py
+++ b/ceph-mon/tests/target.py
@@ -40,6 +40,23 @@ urllib3.disable_warnings(
 )
 
 
+def current_os_release():
+    """Return the OpenStack release index for the deployed ceph-mon.
+
+    zaza's get_os_release derives this from the installed ceph package
+    version through tables that only cover the releases it knows
+    (ceph-common tops out at 19/squid), so on a newer ceph such as
+    tentacle (20) it raises KeyError. A ceph release zaza does not
+    recognise is always newer than any it does, so fall back to a value
+    that sorts after every named release, preserving the "at least
+    release X" comparisons that rely on this.
+    """
+    try:
+        return zaza_openstack.get_os_release(application='ceph-mon')
+    except KeyError:
+        return float('inf')
+
+
 class CephLowLevelTest(test_utils.BaseCharmTest):
     """Ceph Low Level Test Class."""
 
@@ -208,7 +225,7 @@ class CephTest(test_utils.BaseCharmTest):
         Verify that the new disk is added with encryption by checking for
         Ceph's encryption keys directory.
         """
-        current_release = zaza_openstack.get_os_release(application='ceph-mon')
+        current_release = current_os_release()
         trusty_mitaka = zaza_openstack.get_os_release('trusty_mitaka')
         if current_release >= trusty_mitaka:
             logging.warn("Skipping encryption test for Mitaka and higher")
@@ -292,7 +309,7 @@ class CephTest(test_utils.BaseCharmTest):
         As the ephemeral device will have data on it we can use it to validate
         that these checks work as intended.
         """
-        current_release = zaza_openstack.get_os_release(application='ceph-mon')
+        current_release = current_os_release()
         focal_ussuri = zaza_openstack.get_os_release('focal_ussuri')
         if current_release >= focal_ussuri:
             # NOTE(ajkavanagh) - focal (on ServerStack) is broken for /dev/vdb

--- a/ceph-nfs/tests/bundles/noble-caracal.yaml
+++ b/ceph-nfs/tests/bundles/noble-caracal.yaml
@@ -1,5 +1,5 @@
 options:
-  source: &source distro
+  source: &source ppa:johnramsden/noble-caracal-ceph-tentacle
 
 machines:
   '0':

--- a/ceph-nvme/tests/bundles/noble-caracal.yaml
+++ b/ceph-nvme/tests/bundles/noble-caracal.yaml
@@ -20,6 +20,7 @@ applications:
     channel: latest/edge
     options:
       monitor-count: 3
+      source: ppa:johnramsden/noble-caracal-ceph-tentacle
     to:
       - '0'
       - '1'
@@ -41,6 +42,8 @@ applications:
     channel: latest/edge
     storage:
       osd-devices: 'loop,10G'
+    options:
+      source: ppa:johnramsden/noble-caracal-ceph-tentacle
     to:
       - '5'
       - '6'

--- a/ceph-osd/tests/bundles/noble-caracal.yaml
+++ b/ceph-osd/tests/bundles/noble-caracal.yaml
@@ -18,6 +18,7 @@ applications:
     num_units: 3
     options:
       monitor-count: 3
+      source: ppa:johnramsden/noble-caracal-ceph-tentacle
     to:
       - '0'
       - '1'
@@ -29,6 +30,8 @@ applications:
     num_units: 3
     storage:
       osd-devices: 'loop,5G,2'
+    options:
+      source: ppa:johnramsden/noble-caracal-ceph-tentacle
     to:
       - '3'
       - '4'

--- a/ceph-osd/tests/target.py
+++ b/ceph-osd/tests/target.py
@@ -41,6 +41,23 @@ urllib3.disable_warnings(
 )
 
 
+def current_os_release():
+    """Return the OpenStack release index for the deployed ceph-mon.
+
+    zaza's get_os_release derives this from the installed ceph package
+    version through tables that only cover the releases it knows
+    (ceph-common tops out at 19/squid), so on a newer ceph such as
+    tentacle (20) it raises KeyError. A ceph release zaza does not
+    recognise is always newer than any it does, so fall back to a value
+    that sorts after every named release, preserving the "at least
+    release X" comparisons that rely on this.
+    """
+    try:
+        return zaza_openstack.get_os_release(application='ceph-mon')
+    except KeyError:
+        return float('inf')
+
+
 class CephLowLevelTest(test_utils.BaseCharmTest):
     """Ceph Low Level Test Class."""
 
@@ -226,7 +243,7 @@ class CephTest(test_utils.BaseCharmTest):
         Verify that the new disk is added with encryption by checking for
         Ceph's encryption keys directory.
         """
-        current_release = zaza_openstack.get_os_release(application='ceph-mon')
+        current_release = current_os_release()
         trusty_mitaka = zaza_openstack.get_os_release('trusty_mitaka')
         if current_release >= trusty_mitaka:
             logging.warn("Skipping encryption test for Mitaka and higher")
@@ -310,7 +327,7 @@ class CephTest(test_utils.BaseCharmTest):
         As the ephemeral device will have data on it we can use it to validate
         that these checks work as intended.
         """
-        current_release = zaza_openstack.get_os_release(application='ceph-mon')
+        current_release = current_os_release()
         focal_ussuri = zaza_openstack.get_os_release('focal_ussuri')
         if current_release >= focal_ussuri:
             # NOTE(ajkavanagh) - focal (on ServerStack) is broken for /dev/vdb

--- a/ceph-proxy/tests/bundles/noble-caracal.yaml
+++ b/ceph-proxy/tests/bundles/noble-caracal.yaml
@@ -19,6 +19,8 @@ applications:
     num_units: 3
     storage:
       osd-devices: 'loop,4G'
+    options:
+      source: ppa:johnramsden/noble-caracal-ceph-tentacle
     to:
       - '0'
       - '1'
@@ -30,6 +32,7 @@ applications:
     num_units: 3
     options:
       expected-osd-count: 3
+      source: ppa:johnramsden/noble-caracal-ceph-tentacle
     channel: latest/edge
     to:
       - '3'
@@ -41,7 +44,7 @@ applications:
     channel: latest/edge
     num_units: 1
     options:
-      source: distro
+      source: ppa:johnramsden/noble-caracal-ceph-tentacle
     to:
       - '6'
 
@@ -49,11 +52,15 @@ applications:
     charm: ch:ceph-radosgw
     num_units: 1
     channel: latest/edge
+    options:
+      source: ppa:johnramsden/noble-caracal-ceph-tentacle
 
   ceph-fs:
     charm: ch:ceph-fs
     channel: latest/edge
     num_units: 1
+    options:
+      source: ppa:johnramsden/noble-caracal-ceph-tentacle
     to:
       - '2'
 

--- a/ceph-radosgw/tests/bundles/noble-caracal.yaml
+++ b/ceph-radosgw/tests/bundles/noble-caracal.yaml
@@ -1,5 +1,5 @@
 options:
-  source: &source distro
+  source: &source ppa:johnramsden/noble-caracal-ceph-tentacle
 
 series: noble
 

--- a/ceph-radosgw/tests/bundles/noble-tentacle.yaml
+++ b/ceph-radosgw/tests/bundles/noble-tentacle.yaml
@@ -1,5 +1,5 @@
 options:
-  source: &source ppa:johnramsden/noble-caracal-ceph-tentacle-rc
+  source: &source ppa:johnramsden/noble-caracal-ceph-tentacle
 
 series: noble
 

--- a/ceph-radosgw/tests/bundles/noble-tentacle.yaml
+++ b/ceph-radosgw/tests/bundles/noble-tentacle.yaml
@@ -1,0 +1,103 @@
+options:
+  source: &source ppa:johnramsden/noble-caracal-ceph-tentacle-rc
+
+series: noble
+
+comment:
+- 'machines section to decide order of deployment. database sooner = faster'
+machines:
+   '0':
+   '1':
+     constraints: cores=2 mem=6G root-disk=24G virt-type=virtual-machine
+   '2':
+     constraints: cores=2 mem=6G root-disk=24G virt-type=virtual-machine
+   '3':
+     constraints: cores=2 mem=6G root-disk=24G virt-type=virtual-machine
+   '4':
+   '5':
+   '6':
+   '7':
+     series: jammy
+     constraints: cores=2 mem=4G root-disk=12G virt-type=virtual-machine
+   '8':
+
+applications:
+  ceph-radosgw:
+    charm: ch:ceph-radosgw
+    channel: latest/edge
+    num_units: 1
+    options:
+      source: *source
+      namespace-tenants: True
+    to:
+      - '0'
+
+  ceph-osd:
+    charm: ch:ceph-osd
+    num_units: 3
+    storage:
+      osd-devices: 'loop,8G'
+    options:
+      source: *source
+      osd-devices: '/srv/ceph /dev/test-non-existent'
+    to:
+      - '1'
+      - '2'
+      - '3'
+    channel: latest/edge
+
+  ceph-mon:
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      monitor-count: 3
+      source: *source
+    to:
+      - '4'
+      - '5'
+      - '6'
+    channel: latest/edge
+
+  vault:
+    charm: ch:vault
+    num_units: 1
+    channel: latest/edge
+    to:
+      - '0'
+
+  mysql:
+    charm: ch:mysql
+    num_units: 1
+    channel: 8.0/stable
+    series: jammy
+    to:
+      - '7'
+
+  keystone:
+    charm: ch:keystone
+    channel: latest/edge
+    num_units: 1
+    to:
+      - '8'
+
+relations:
+  - - 'ceph-osd:mon'
+    - 'ceph-mon:osd'
+
+  - - 'ceph-radosgw:mon'
+    - 'ceph-mon:radosgw'
+
+  - - 'keystone'
+    - 'mysql'
+
+  - - 'vault:shared-db'
+    - 'mysql:shared-db'
+
+  - - 'keystone:certificates'
+    - 'vault:certificates'
+
+  - - 'ceph-radosgw:certificates'
+    - 'vault:certificates'
+
+  - - 'ceph-radosgw:identity-service'
+    - 'keystone:identity-service'

--- a/ceph-radosgw/tests/target.py
+++ b/ceph-radosgw/tests/target.py
@@ -21,6 +21,9 @@ import pprint
 import requests
 from requests.adapters import HTTPAdapter
 import boto3
+import botocore.auth
+import botocore.awsrequest
+import botocore.credentials
 import botocore.exceptions
 import urllib3
 
@@ -716,6 +719,228 @@ class CephRGWTest(test_utils.BaseCharmTest):
             }
         )
         zaza_model.wait_for_unit_idle(self.primary_rgw_unit)
+
+    def run_rgwadmin(self, unit_name, args):
+        """Run a radosgw-admin subcommand on a unit and check it succeeded.
+
+        :param unit_name: Unit to run the command on.
+        :type unit_name: str
+        :param args: radosgw-admin arguments, without the command name.
+        :type args: str
+        :returns: Command stdout.
+        :rtype: str
+        """
+        cmd = self.get_rgwadmin_cmd_skeleton(unit_name) + args
+        result = zaza_model.run_on_unit(unit_name, cmd)
+        self.assertEqual(
+            int(result.get('Code')), 0,
+            'command failed: {}\nstdout: {}\nstderr: {}'.format(
+                cmd, result.get('Stdout'), result.get('Stderr')
+            )
+        )
+        return result.get('Stdout', '')
+
+    def create_datalog_reader(self, unit_name):
+        """Create an RGW user holding the datalog read cap.
+
+        A dedicated user is created rather than adding the cap to the
+        existing boto3 user, because RGW caches user info and that user has
+        already been used for S3 by the time this runs, so a cap added to it
+        is not necessarily live yet.
+
+        :param unit_name: RGW unit to create the user on.
+        :type unit_name: str
+        :returns: access_key and secret_key for the new user.
+        :rtype: (str, str)
+        """
+        user_name = 'zaza-datalog'
+        users = json.loads(self.run_rgwadmin(unit_name, 'user list'))
+        if user_name not in users:
+            self.run_rgwadmin(
+                unit_name,
+                'user create --uid={} --display-name={} '
+                '--caps="datalog=read"'.format(user_name, user_name)
+            )
+        else:
+            self.run_rgwadmin(
+                unit_name,
+                'caps add --uid={} --caps="datalog=read"'.format(user_name)
+            )
+
+        info = json.loads(
+            self.run_rgwadmin(unit_name, 'user info --uid={}'.format(
+                user_name))
+        )
+        caps = info.get('caps', [])
+        logging.info('{} caps: {}'.format(user_name, caps))
+        self.assertIn(
+            {'type': 'datalog', 'perm': 'read'}, caps,
+            'datalog=read cap was not applied to {}: {}'.format(
+                user_name, caps)
+        )
+        keys = info['keys'][0]
+        return keys['access_key'], keys['secret_key']
+
+    def signed_admin_get(self, endpoint, access_key, secret_key, params):
+        """Send a SigV4 signed GET to the RGW admin API.
+
+        Equivalent of `curl --aws-sigv4 "aws:amz:us-east-1:s3"`. The region
+        only has to be self consistent, since RGW recomputes the signature
+        from the scope in the Authorization header it is given.
+
+        :param endpoint: RGW endpoint URL, as get_rgw_endpoint returns.
+        :type endpoint: str
+        :param access_key: S3 access key for the signing user.
+        :type access_key: str
+        :param secret_key: S3 secret key for the signing user.
+        :type secret_key: str
+        :param params: Query string arguments for /admin/log.
+        :type params: dict
+        :returns: The HTTP response.
+        :rtype: requests.Response
+        """
+        credentials = botocore.credentials.Credentials(access_key, secret_key)
+        request = botocore.awsrequest.AWSRequest(
+            method='GET', url=endpoint + '/admin/log', params=params
+        )
+        # S3SigV4Auth, not SigV4Auth: RGW rejects a signature that does not
+        # cover x-amz-content-sha256, and only the S3 variant sends it. The
+        # plain signer omits it and RGW reports that as InvalidAccessKeyId,
+        # which reads like a bad key rather than a malformed signature.
+        botocore.auth.S3SigV4Auth(credentials, 's3', 'us-east-1').add_auth(
+            request
+        )
+        prepared = request.prepare()
+        return requests.get(
+            prepared.url, headers=dict(prepared.headers), verify=False
+        )
+
+    def assert_admin_get_ok(self, endpoint, access_key, secret_key, params,
+                            expected_key):
+        """Assert a signed admin GET returns 200 with the expected content.
+
+        Retried briefly, because a cap granted moments earlier is not always
+        visible to RGW straight away.
+
+        :param endpoint: RGW endpoint URL.
+        :type endpoint: str
+        :param access_key: S3 access key for the signing user.
+        :type access_key: str
+        :param secret_key: S3 secret key for the signing user.
+        :type secret_key: str
+        :param params: Query string arguments for /admin/log.
+        :type params: dict
+        :param expected_key: Key that must appear in the JSON response.
+        :type expected_key: str
+        :returns: The HTTP response.
+        :rtype: requests.Response
+        """
+        for attempt in tenacity.Retrying(
+            wait=tenacity.wait_fixed(15), reraise=True,
+            stop=tenacity.stop_after_attempt(4),
+            retry=tenacity.retry_if_exception_type(AssertionError)
+        ):
+            with attempt:
+                response = self.signed_admin_get(
+                    endpoint, access_key, secret_key, params
+                )
+                self.assertEqual(
+                    response.status_code, 200,
+                    'GET /admin/log {} returned {}: {}'.format(
+                        params, response.status_code, response.text[:500]
+                    )
+                )
+                self.assertIn(expected_key, response.json())
+        return response
+
+    def test_005_admin_datalog_shard_info(self):
+        """Verify a successful admin datalog shard-info request.
+
+        Regression test for canonical/microceph#810. Ceph 20.2.1 built
+        against boost 1.83 (Noble's system boost, below upstream's 1.87
+        floor) crashes radosgw on requests that *succeed*: rgw::run_coro<>
+        in src/rgw/async_utils.h hands the coroutine completion straight to
+        the yield context, and boost 1.83's spawn.hpp on_resume() checks
+        whether the exception_ptr is set rather than what it holds, so it
+        rethrows on every completion, including the ones with no exception
+        stored.
+
+        RGWOp_DATALog_ShardInfo::execute() is one such call site. RGW
+        multisite data sync polls it on its peer every sync cycle, which is
+        how the bug surfaced, but it needs neither a peer zone nor any user
+        data to reproduce, so this does not gate on self.multisite.
+
+        Only a shard that exists is requested. An out of range shard id is
+        not a usable control here: on squid 19.2.3 it takes radosgw down
+        with SIGABRT out of the same boost::asio spawn machinery, via
+        std::unexpected in spawned_thread_rethrow, so probing one would
+        leave nothing running to answer the request that matters.
+        """
+        unit_name = self.primary_rgw_unit
+        endpoint = self.get_rgw_endpoint(unit_name)
+        self.assertIsNotNone(endpoint)
+
+        access_key, secret_key = self.create_datalog_reader(unit_name)
+
+        # Baseline: the shard count is served without entering the coroutine
+        # path at all, so it confirms endpoint, keys and caps are good before
+        # anything is concluded from a failure below.
+        logging.info('Checking admin datalog shard count')
+        self.assert_admin_get_ok(
+            endpoint, access_key, secret_key, {'type': 'data'}, 'num_objects'
+        )
+
+        pids_before = zaza_utils.get_unit_process_ids(
+            {unit_name: {'radosgw': 1}}
+        )
+
+        # The regression itself: a shard-info lookup that succeeds. On an
+        # affected build radosgw dies handling it, which reaches the client
+        # in one of two ways. Hitting radosgw directly, the connection drops
+        # and requests raises. Through the charm's haproxy, the backend goes
+        # away mid-request and haproxy answers 502 (or 503). Either is the
+        # #810 signature, so both are reported as such rather than left to
+        # look like an ordinary bad status or a flaky network. No retry
+        # here: a crash is not transient, and retrying would just crash the
+        # freshly restarted daemon again.
+        logging.info('Checking admin datalog shard info for shard 0')
+        crash_note = (
+            'This is the signature of canonical/microceph#810, where Ceph '
+            '20.2.1 built against boost 1.83 crashes radosgw on successful '
+            'admin datalog shard-info requests.'
+        )
+        try:
+            response = self.signed_admin_get(
+                endpoint, access_key, secret_key,
+                {'type': 'data', 'id': '0', 'info': ''}
+            )
+        except requests.exceptions.RequestException as e:
+            self.fail(
+                'radosgw dropped the connection on a successful admin '
+                'datalog shard-info request: {}. {}'.format(e, crash_note)
+            )
+        if response.status_code in (502, 503):
+            self.fail(
+                'haproxy returned {} for a successful admin datalog '
+                'shard-info request, i.e. the radosgw backend died handling '
+                'it. {}'.format(response.status_code, crash_note)
+            )
+        self.assertEqual(
+            response.status_code, 200,
+            'GET /admin/log {} returned {}: {}'.format(
+                {'type': 'data', 'id': '0', 'info': ''},
+                response.status_code, response.text[:500]
+            )
+        )
+        self.assertIn('marker', response.json())
+
+        # Even if a crashed radosgw was restarted quickly enough to answer,
+        # the PID would change, so confirm the daemon is the one that
+        # started the test.
+        pids_after = zaza_utils.get_unit_process_ids(
+            {unit_name: {'radosgw': 1}}
+        )
+        self.assertEqual(pids_before, pids_after)
 
     def test_100_migration_and_multisite_failover(self):
         """Perform multisite migration and verify failover."""

--- a/ceph-radosgw/tests/target.py
+++ b/ceph-radosgw/tests/target.py
@@ -18,6 +18,7 @@ import unittest
 import json
 import logging
 import pprint
+import re
 import requests
 from requests.adapters import HTTPAdapter
 import boto3
@@ -35,7 +36,6 @@ import zaza.openstack.utilities.ceph as zaza_ceph
 import zaza.openstack.utilities.generic as zaza_utils
 import zaza.utilities.networking as network_utils
 import zaza.utilities.juju as juju_utils
-import zaza.openstack.utilities.openstack as zaza_openstack
 import zaza.openstack.utilities.generic as generic_utils
 import zaza.openstack.utilities.openstack as openstack_utils
 
@@ -1088,13 +1088,37 @@ class CephRGWTest(test_utils.BaseCharmTest):
         self.purge_bucket(self.secondary_rgw_app, 'zaza-container')
         self.purge_bucket(self.secondary_rgw_app, 'failover-container')
 
+    def ceph_release_number(self, unit_name='ceph-mon/0'):
+        """Return the installed Ceph major version number.
+
+        Read straight from `ceph --version` rather than through zaza's
+        OpenStack codename tables, which map only the ceph releases zaza
+        knows about and raise KeyError on newer ones (e.g. tentacle, 20).
+        The daemon version is enough for the reef/squid/tentacle gates the
+        tests need and does not depend on cluster access.
+
+        :param unit_name: Unit to read the version from.
+        :type unit_name: str
+        :returns: The Ceph major version, e.g. 19 for squid or 20 for
+            tentacle.
+        :rtype: int
+        """
+        stdout = zaza_model.run_on_unit(
+            unit_name, 'ceph --version'
+        ).get('Stdout', '')
+        # e.g. "ceph version 20.2.1 (...) tentacle (stable)"
+        match = re.search(r'ceph version (\d+)\.', stdout)
+        if match is None:
+            raise AssertionError(
+                'could not parse ceph version from: {}'.format(stdout))
+        return int(match.group(1))
+
     def test_101_virtual_hosted_bucket(self):
         """Test virtual hosted bucket."""
-        # skip if quincy or older
-        current_release = zaza_openstack.get_os_release(
-            application='ceph-mon')
-        reef = zaza_openstack.get_os_release('jammy_bobcat')
-        if current_release < reef:
+        # Virtual hosted buckets need reef (Ceph 18) or newer. Gate on the
+        # Ceph version directly; zaza's get_os_release raises on releases
+        # newer than it knows, which would break this on tentacle.
+        if self.ceph_release_number() < 18:
             raise unittest.SkipTest(
                 'Virtual hosted bucket not supported in quincy or older')
 

--- a/ceph-radosgw/tests/tests.yaml
+++ b/ceph-radosgw/tests/tests.yaml
@@ -7,7 +7,7 @@ smoke_bundles:
   - noble-caracal
 
 dev_bundles:
-  - noble-caracal
+  - noble-tentacle
 
 target_deploy_status:
   vault:

--- a/ceph-rbd-mirror/src/tests/bundles/noble-caracal.yaml
+++ b/ceph-rbd-mirror/src/tests/bundles/noble-caracal.yaml
@@ -1,5 +1,6 @@
 variables:
   openstack-origin: &openstack-origin distro
+  source: &source ppa:johnramsden/noble-caracal-ceph-tentacle
   series: &series noble
 
 series: *series
@@ -30,7 +31,7 @@ applications:
     num_units: 3
     options:
       expected-osd-count: 3
-      source: *openstack-origin
+      source: *source
     channel: latest/edge
     to:
       - '6'
@@ -43,7 +44,7 @@ applications:
     storage:
       osd-devices: 'loop,4G'
     options:
-      source: *openstack-origin
+      source: *source
       osd-devices: '/dev/test-non-existent'
     channel: latest/edge
     to:
@@ -57,7 +58,7 @@ applications:
     channel: latest/edge
     num_units: 1
     options:
-      source: *openstack-origin
+      source: *source
     to:
       - '0'
 
@@ -66,7 +67,7 @@ applications:
     num_units: 3
     options:
       expected-osd-count: 3
-      source: *openstack-origin
+      source: *source
     channel: latest/edge
     to:
       - '9'
@@ -79,7 +80,7 @@ applications:
     storage:
       osd-devices: 'loop,4G'
     options:
-      source: *openstack-origin
+      source: *source
       osd-devices: '/dev/test-non-existent'
     channel: latest/edge
     to:
@@ -93,7 +94,7 @@ applications:
     channel: latest/edge
     num_units: 1
     options:
-      source: *openstack-origin
+      source: *source
     to:
       - '3'
 


### PR DESCRIPTION
Regression test for the RGW admin-datalog segfault (microceph#810 (https://github.com/canonical/microceph/issues/810)), shown fail -> pass against the tentacle PPA (https://launchpad.net/~johnramsden/+archive/ubuntu/noble-caracal-ceph-tentacle), then run across all charms.

- FAIL (current ppa): test_005 fails with the #810 signature (https://github.com/canonical/ceph-charms/actions/runs/32203910579/job/95924121412)
- PASS fixed build (new PPA): ceph-radosgw suite passes (https://github.com/canonical/ceph-charms/actions/runs/32207633349/job/95934867014)
- PASS all charms on the tentacle PPA: 8/9 pass (https://github.com/canonical/ceph-charms/actions/runs/32278979438), only ceph-dashboard fails (https://github.com/canonical/ceph-charms/actions/runs/32278979438/job/96293605157)