### PR TITLE
ci: disable IPv6 on lxdbr0 for functional tests (squid)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -155,6 +155,15 @@ jobs:
             newgrp lxd
             lxd init --minimal
           fi
+          # Disable IPv6 on the default bridge. Otherwise model machines get
+          # an IPv6 address alongside their IPv4 one, and zaza's vault setup
+          # reaches keystone over HTTPS by machine address; the vault-issued
+          # certificate only covers the IPv4 SAN, so when the IPv6 address is
+          # picked, cert validation fails and the whole run aborts in the
+          # configure step before any test runs. Runs unconditionally because
+          # a self-hosted runner may already have lxdbr0 up with IPv6 enabled,
+          # skipping the init above.
+          sudo lxc network set lxdbr0 ipv6.address none
 
       - name: Install and configure tests
         run: |


### PR DESCRIPTION
# Description

Functional test runs intermittently abort in the configure step with an SSL certificate validation error against keystone, e.g.:

```
  certificate verify failed: IP address mismatch, certificate is not
  valid for 'fd42:...'  (keystone :5000)
```

The default LXD bridge hands out an IPv6 address alongside IPv4, and zaza's vault setup (auto_initialize -> validate_ca) reaches keystone over HTTPS by machine address. The vault-issued certificate only covers the IPv4 SAN, so whenever the IPv6 address is chosen the handshake fails and the whole run dies before any test executes. It is a coin flip per run and is unrelated to the code under test.

Disable IPv6 on lxdbr0 in the functional-test job's LXD setup so model machines are IPv4 only. Run it unconditionally: a self-hosted runner may already have lxdbr0 up with IPv6 from a previous run, in which case the install block above is skipped.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] CleanCode (Code refactor, test updates, does not introduce functional changes)
- [x] Documentation update (Doc only change)