### PR TITLE
feat: ceph-nvme: Add a source config option

### DIFF
--- a/ceph-nvme/config.yaml
+++ b/ceph-nvme/config.yaml
@@ -1,4 +1,22 @@
 options:
+  source:
+    type: string
+    default: distro
+    description: |
+      Optional configuration to support use of additional sources such as:
+      .
+        - ppa:myteam/ppa
+        - cloud:noble-caracal
+        - http://my.archive.com/ubuntu main
+      .
+      The last option should be used in conjunction with the key configuration
+      option.
+  key:
+    type: string
+    default:
+    description: |
+      Key ID to import to the apt keyring to support use with arbitary source
+      configuration from outside of Launchpad archives or PPA's.
   cpuset:
     type: string
     default: ''

--- a/ceph-nvme/src/charm.py
+++ b/ceph-nvme/src/charm.py
@@ -24,6 +24,7 @@ import random
 import socket
 import subprocess
 
+import charmhelpers.fetch as fetch
 import interface_ceph_client.ceph_client as ceph_client
 import interface_ceph_iscsi_admin_access.admin_access as admin_access
 import ops
@@ -574,7 +575,14 @@ class CephNVMECharm(ops.CharmBase):
     def on_config_changed(self, event):
         self._render_config()
 
+    def _configure_source(self):
+        source = self.config.get('source')
+        if source and source != 'distro':
+            fetch.add_source(source, self.config.get('key'))
+            fetch.apt_update(fatal=True)
+
     def _install_systemd_services(self):
+        self._configure_source()
         self._install_packages(self.PACKAGES)
         config_path = self._render_config()
         utils.setup_hugepages(int(self.config['nr-hugepages']))


### PR DESCRIPTION
<!-- Branch: ceph-nvme-source-option -> main -->
<!-- Files: ceph-nvme/config.yaml, ceph-nvme/src/charm.py -->
<!-- Title: ceph-nvme: Add a source config option -->

# Description

ceph-nvme installs the Ceph client packages (`librados-dev`, `librbd-dev`, `python3-rados`, `python3-rbd`) only from the Ubuntu archive. It is the only ceph charm without a `source` option, so its units cannot get client libraries from the Ubuntu Cloud Archive or a PPA to match the cluster.

Add the standard `source` and `key` options, with the same wording as ceph-osd and ceph-nfs. The install hook applies them with charmhelpers `add_source` plus `apt update` before installing the packages. The default is `distro`, which changes nothing for existing deployments.

ceph-nvme is a plain `ops.CharmBase` charm, so the handling is written in the charm instead of inherited from `OSBaseCharm` like ceph-nfs:
https://opendev.org/openstack/charm-ops-openstack/src/branch/master/ops_openstack/core.py

The option is applied only at install time. Changing `source` on a deployed unit has no effect until the packages are upgraded and the services restarted by hand. This matches ceph-nfs, where `OSBaseCharm.install_pkgs()` likewise runs only from the install hook:
https://opendev.org/openstack/charm-ops-openstack/src/commit/ce343b907412340e2d5f24b6f53ef93a40e892fd/ops_openstack/core.py#L79-L90
Fixing it needs a rolling restart of the gateways.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Exercised on the 19.2.6 SRU test branch (#220), which points the noble-caracal test bundle's `source` at the SRU staging PPA so the functional tests deploy matching client packages. No unit tests added; the install path is not covered by the unit test harness, same as the source handling in the other charms.

## Contributor's Checklist

- [x] considered and tested upgrade scenarios from a previous stable version.
- [x] self-reviewed the code in this PR.